### PR TITLE
Use AWS SDK for PHP v3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor**
+.idea/*

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,2 +1,7 @@
 tools:
     external_code_coverage: true
+
+checks:
+    php:
+        code_rating: true
+        duplication: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: php
 php:
+  - 7.0
   - 5.6
   - 5.5
-  - 5.4
-  - 5.3
 install: composer install
 script: phpunit --coverage-clover=coverage.clover
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 php:
+  - nightly
+  - 7.1
   - 7.0
   - 5.6
   - 5.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 php:
   - nightly
   - 7.1
-  - 7.0
 install: composer install
 script: phpunit --coverage-clover=coverage.clover
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ php:
   - nightly
   - 7.1
   - 7.0
-  - 5.6
-  - 5.5
 install: composer install
 script: phpunit --coverage-clover=coverage.clover
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ install: composer install
 script: phpunit --coverage-clover=coverage.clover
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar
-  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover --repository=limenet/s3-bucket-stream-zip-php

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ Uses v3 of AWS SDK to stream files directly from S3.
 
 ```
 composer require limenet/s3-bucket-stream-zip-php
-composer install
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # S3BucketStreamZip
 
-[![Build Status](https://travis-ci.org/jmathai/s3-bucket-stream-zip-php.svg?branch=master)](https://travis-ci.org/jmathai/s3-bucket-stream-zip-php)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/jmathai/s3-bucket-stream-zip-php/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/jmathai/s3-bucket-stream-zip-php/?branch=master)
-[![Code Coverage](https://scrutinizer-ci.com/g/jmathai/s3-bucket-stream-zip-php/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/jmathai/s3-bucket-stream-zip-php/?branch=master)
+[![Build Status](https://travis-ci.org/limenet/s3-bucket-stream-zip-php.svg?branch=master)](https://travis-ci.org/limenet/s3-bucket-stream-zip-php)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/limenet/s3-bucket-stream-zip-php/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/limenet/s3-bucket-stream-zip-php/?branch=master)
+[![Code Coverage](https://scrutinizer-ci.com/g/limenet/s3-bucket-stream-zip-php/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/limenet/s3-bucket-stream-zip-php/?branch=master)
 
 ## Overview
 This library lets you efficiently stream the contents of an S3 bucket/folder as a zip file to the client.
 
 ## Installation
-Installation is done via composer by adding the a dependency on jmathai/s3-bucket-stream-zip-php.
+Installation is done via composer by adding the a dependency on limenet/s3-bucket-stream-zip-php.
 
 ```
-composer require jmathai/s3-bucket-stream-zip-php
+composer require limenet/s3-bucket-stream-zip-php
 composer install
 ```
 
@@ -44,6 +44,7 @@ $stream->send('name-of-zipfile-to-send.zip');
 
 ## Authors
 * Jaisen Mathai <jaisen@jmathai.com> - http://jaisenmathai.com
+* Linus Metzler <hi@linusmetzler.me> - https://linusmetzler.me
 
 ## Dependencies
 * Paul Duncan <pabs@pablotron.org> - http://pablotron.org/

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ in `config/app.php`:
 ```php
 'providers' => [
     ...
-    limenet\S3BucketStreamZip\AWSZipStreamServiceProvider::class,
+    limenet\S3BucketStreamZip\AwsZipStreamServiceProvider::class,
     ...
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -4,11 +4,14 @@
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/limenet/s3-bucket-stream-zip-php/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/limenet/s3-bucket-stream-zip-php/?branch=master)
 [![Code Coverage](https://scrutinizer-ci.com/g/limenet/s3-bucket-stream-zip-php/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/limenet/s3-bucket-stream-zip-php/?branch=master)
 
+Forked from `jmathai/s3-bucket-stream-zip-php` and `michaeltlee/s3-bucket-stream-zip-php`
+
 ## Overview
 This library lets you efficiently stream the contents of an S3 bucket/folder as a zip file to the client.
 
+Uses v3 of AWS SDK to stream files directly from S3.
+
 ## Installation
-Installation is done via composer by adding the a dependency on limenet/s3-bucket-stream-zip-php.
 
 ```
 composer require limenet/s3-bucket-stream-zip-php
@@ -16,28 +19,34 @@ composer install
 ```
 
 ## Usage
+
+See `examples/simple.php`.
+
+## Laravel 5.4
+
+in `config/app.php`:
+
 ```php
-// taken from examples/simple.php
+'providers' => [
+    ...
+    limenet\S3BucketStreamZip\AWSZipStreamServiceProvider::class,
+    ...
+]
+```
 
-require 'vendor/autoload.php';
-
-use JMathai\S3BucketStreamZip\S3BucketStreamZip;
-
-$stream = new S3BucketStreamZip([
-    'key'    => 'your-key-goes-here',
-    'secret' => 'your-secret-goes-here',
-    'bucket' => 'the-name-of-your-bucket',
-    'region' => 'the-region-of-your-bucket',
-    'prefix' => 'prefix-of-the-files-to-zip',
-  ]);
-
-$stream->send('name-of-zipfile-to-send.zip');
-
-
+in `config/services.php`, set:
+```php
+'s3' => [
+    'key'     => '',
+    'secret'  => '',
+    'region'  => '',
+    'version' => '',
+];
 ```
 
 ## Authors
 * Jaisen Mathai <jaisen@jmathai.com> - http://jaisenmathai.com
+* [@Michaeltlee](https://github.com/Michaeltlee)
 * Linus Metzler <hi@linusmetzler.me> - https://linusmetzler.me
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -18,27 +18,21 @@ composer install
 ## Usage
 ```php
 // taken from examples/simple.php
-// since large buckets may take lots of time we remove any time limits
-set_time_limit(0);
-require sprintf('%s/../vendor/autoload.php', __DIR__);
+
+require 'vendor/autoload.php';
 
 use JMathai\S3BucketStreamZip\S3BucketStreamZip;
-use JMathai\S3BucketStreamZip\Exception\InvalidParameterException;
 
-$stream = new S3BucketStreamZip(
-            // $auth
-            array(
-              'key'     => '*********',   // required
-              'secret'  => '*********'    // required
-            ),
-            // $params
-            array(
-              'Bucket'  => 'bucketname',  // required
-              'Prefix'  => 'subfolder/'   // optional (path to folder to stream)
-            )
-          );
+$stream = new S3BucketStreamZip([
+    'key'    => 'your-key-goes-here',
+    'secret' => 'your-secret-goes-here',
+    'bucket' => 'the-name-of-your-bucket',
+    'region' => 'the-region-of-your-bucket',
+    'prefix' => 'prefix-of-the-files-to-zip',
+  ]);
 
 $stream->send('name-of-zipfile-to-send.zip');
+
 
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   "require": {
     "php": ">=5.3.3",
     "maennchen/zipstream-php": "0.3.*",
-    "aws/aws-sdk-php": "2.*"
+    "aws/aws-sdk-php": "^3.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.0"

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-  "name": "jmathai/s3-bucket-stream-zip-php",
-  "homepage": "https://github.com/jmathai/s3-bucket-stream-zip-php",
+  "name": "limenet/s3-bucket-stream-zip-php",
+  "homepage": "https://github.com/limenet/s3-bucket-stream-zip-php",
   "description": "PHP library to efficiently stream contents from an AWS S3 bucket or folder as a zip file",
   "keywords": ["amazon","aws","s3","stream","zip","php","download"],
   "type": "library",
@@ -10,10 +10,15 @@
       "name": "Jaisen Mathai",
       "email": "jaisen@jmathai.com",
       "homepage": "http://jaisenmathai.com/"
+    },
+    {
+      "name": "Linus Metzler",
+      "email": "hi@linusmetzler.me",
+      "homepage": "https://linusmetzler.me/"
     }
   ],
   "support": {
-    "issues": "https://github.com/jmathai/s3-bucket-stream-zip-php/issues"
+    "issues": "https://github.com/limenet/s3-bucket-stream-zip-php/issues"
   },
   "require": {
     "php": ">=5.3.3",

--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,11 @@
   },
   "require": {
     "php": ">=5.3.3",
-    "maennchen/zipstream-php": "0.3.*",
+    "maennchen/zipstream-php": "0.4.*",
     "aws/aws-sdk-php": "^3.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "~4.0"
+    "phpunit/phpunit": "~5.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-  "name": "limenet/s3-bucket-stream-zip-php",
-  "homepage": "https://github.com/limenet/s3-bucket-stream-zip-php",
+  "name": "michaeltlee/s3-bucket-stream-zip-php",
+  "homepage": "https://github.com/michaeltlee/s3-bucket-stream-zip-php",
   "description": "PHP library to efficiently stream contents from an AWS S3 bucket or folder as a zip file",
   "keywords": ["amazon","aws","s3","stream","zip","php","download"],
   "type": "library",
@@ -22,15 +22,15 @@
   },
   "require": {
     "php": ">=7.0",
-    "maennchen/zipstream-php": "0.4.*",
-    "aws/aws-sdk-php": "^3.0"
+    "maennchen/zipstream-php": "0.3.*",
+    "aws/aws-sdk-php": "3.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~5.0"
   },
   "autoload": {
     "psr-4": {
-      "JMathai\\S3BucketStreamZip\\": "src/"
+      "limenet\\S3BucketStreamZip\\": "src/"
     }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "issues": "https://github.com/limenet/s3-bucket-stream-zip-php/issues"
   },
   "require": {
-    "php": ">=5.3.3",
+    "php": ">=7.0",
     "maennchen/zipstream-php": "0.4.*",
     "aws/aws-sdk-php": "^3.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
   },
   "require": {
     "php": ">=7.0",
-    "maennchen/zipstream-php": "0.3.*",
-    "aws/aws-sdk-php": "3.0"
+    "maennchen/zipstream-php": "^0.4",
+    "aws/aws-sdk-php": "^3.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~5.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "26177f7c54cd4dd3dbd6de0809901b47",
-    "content-hash": "3efa5940c65bdda57118f84129e80927",
+    "content-hash": "7450bd80eb67c87de316c996fc022cb8",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.19.4",
+            "version": "3.22.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "f67bc37fa4b76d85423052eae2a9577aab99adc1"
+                "reference": "b6b5fa3c8c1b34db822e95fa764de01869493ebe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/f67bc37fa4b76d85423052eae2a9577aab99adc1",
-                "reference": "f67bc37fa4b76d85423052eae2a9577aab99adc1",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/b6b5fa3c8c1b34db822e95fa764de01869493ebe",
+                "reference": "b6b5fa3c8c1b34db822e95fa764de01869493ebe",
                 "shasum": ""
             },
             "require": {
@@ -85,20 +84,20 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2016-09-01 21:37:32"
+            "time": "2017-02-24T00:41:00+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "6.2.1",
+            "version": "6.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "3f808fba627f2c5b69e2501217bf31af349c1427"
+                "reference": "ebf29dee597f02f09f4d5bbecc68230ea9b08f60"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/3f808fba627f2c5b69e2501217bf31af349c1427",
-                "reference": "3f808fba627f2c5b69e2501217bf31af349c1427",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/ebf29dee597f02f09f4d5bbecc68230ea9b08f60",
+                "reference": "ebf29dee597f02f09f4d5bbecc68230ea9b08f60",
                 "shasum": ""
             },
             "require": {
@@ -147,32 +146,32 @@
                 "rest",
                 "web service"
             ],
-            "time": "2016-07-15 17:22:37"
+            "time": "2016-10-08T15:01:37+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "1.2.0",
+            "version": "v1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "c10d860e2a9595f8883527fa0021c7da9e65f579"
+                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/c10d860e2a9595f8883527fa0021c7da9e65f579",
-                "reference": "c10d860e2a9595f8883527fa0021c7da9e65f579",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/a59da6cf61d80060647ff4d3eb2c03a2bc694646",
+                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "^4.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "1.4-dev"
                 }
             },
             "autoload": {
@@ -198,7 +197,7 @@
             "keywords": [
                 "promise"
             ],
-            "time": "2016-05-18 16:56:05"
+            "time": "2016-12-20T10:07:11+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
@@ -256,25 +255,25 @@
                 "stream",
                 "uri"
             ],
-            "time": "2016-06-24 23:00:38"
+            "time": "2016-06-24T23:00:38+00:00"
         },
         {
             "name": "maennchen/zipstream-php",
-            "version": "0.3.1",
+            "version": "v0.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/maennchen/ZipStream-PHP.git",
-                "reference": "c492ddf4abcb0f6bed287faae35ebe77be7b690f"
+                "reference": "89e0cdb3c9ecabef4da988852003781a7802afb7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/maennchen/ZipStream-PHP/zipball/c492ddf4abcb0f6bed287faae35ebe77be7b690f",
-                "reference": "c492ddf4abcb0f6bed287faae35ebe77be7b690f",
+                "url": "https://api.github.com/repos/maennchen/ZipStream-PHP/zipball/89e0cdb3c9ecabef4da988852003781a7802afb7",
+                "reference": "89e0cdb3c9ecabef4da988852003781a7802afb7",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "php": ">= 5.3"
+                "php": ">= 5.6"
             },
             "require-dev": {
                 "phpunit/phpunit": "4.3.*"
@@ -308,20 +307,20 @@
                 "stream",
                 "zip"
             ],
-            "time": "2016-02-27 22:32:42"
+            "time": "2016-09-13T10:29:17+00:00"
         },
         {
             "name": "mtdowling/jmespath.php",
-            "version": "2.3.0",
+            "version": "2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jmespath/jmespath.php.git",
-                "reference": "192f93e43c2c97acde7694993ab171b3de284093"
+                "reference": "adcc9531682cf87dfda21e1fd5d0e7a41d292fac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/192f93e43c2c97acde7694993ab171b3de284093",
-                "reference": "192f93e43c2c97acde7694993ab171b3de284093",
+                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/adcc9531682cf87dfda21e1fd5d0e7a41d292fac",
+                "reference": "adcc9531682cf87dfda21e1fd5d0e7a41d292fac",
                 "shasum": ""
             },
             "require": {
@@ -363,7 +362,7 @@
                 "json",
                 "jsonpath"
             ],
-            "time": "2016-01-05 18:25:05"
+            "time": "2016-12-03T22:08:25+00:00"
         },
         {
             "name": "psr/http-message",
@@ -413,7 +412,7 @@
                 "request",
                 "response"
             ],
-            "time": "2016-08-06 14:39:51"
+            "time": "2016-08-06T14:39:51+00:00"
         }
     ],
     "packages-dev": [
@@ -469,7 +468,49 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14 21:17:01"
+            "time": "2015-06-14T21:17:01+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "5a5a9fc8025a08d8919be87d6884d5a92520cefe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/5a5a9fc8025a08d8919be87d6884d5a92520cefe",
+                "reference": "5a5a9fc8025a08d8919be87d6884d5a92520cefe",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "doctrine/collections": "1.*",
+                "phpunit/phpunit": "~4.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "homepage": "https://github.com/myclabs/DeepCopy",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "time": "2017-01-26T22:05:40+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -523,20 +564,20 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2015-12-27 11:43:31"
+            "time": "2015-12-27T11:43:31+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "3.1.0",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "9270140b940ff02e58ec577c237274e92cd40cdd"
+                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/9270140b940ff02e58ec577c237274e92cd40cdd",
-                "reference": "9270140b940ff02e58ec577c237274e92cd40cdd",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/8331b5efe816ae05461b7ca1e721c01b46bafb3e",
+                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e",
                 "shasum": ""
             },
             "require": {
@@ -568,20 +609,20 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2016-06-10 09:48:41"
+            "time": "2016-09-30T07:12:33+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "0.2",
+            "version": "0.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443"
+                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/b39c7a5b194f9ed7bd0dd345c751007a41862443",
-                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
+                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
                 "shasum": ""
             },
             "require": {
@@ -615,20 +656,20 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-06-10 07:14:17"
+            "time": "2016-11-25T06:54:22+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.6.1",
+            "version": "v1.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "58a8137754bc24b25740d4281399a4a3596058e0"
+                "reference": "6c52c2722f8460122f96f86346600e1077ce22cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/58a8137754bc24b25740d4281399a4a3596058e0",
-                "reference": "58a8137754bc24b25740d4281399a4a3596058e0",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/6c52c2722f8460122f96f86346600e1077ce22cb",
+                "reference": "6c52c2722f8460122f96f86346600e1077ce22cb",
                 "shasum": ""
             },
             "require": {
@@ -636,10 +677,11 @@
                 "php": "^5.3|^7.0",
                 "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
                 "sebastian/comparator": "^1.1",
-                "sebastian/recursion-context": "^1.0"
+                "sebastian/recursion-context": "^1.0|^2.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^2.0"
+                "phpspec/phpspec": "^2.0",
+                "phpunit/phpunit": "^4.8 || ^5.6.5"
             },
             "type": "library",
             "extra": {
@@ -677,43 +719,44 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-06-07 08:13:47"
+            "time": "2016-11-21T14:58:47+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "2.2.4",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979"
+                "reference": "ca060f645beeddebedb1885c97bf163e93264c35"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/eabf68b476ac7d0f73793aada060f1c1a9bf8979",
-                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ca060f645beeddebedb1885c97bf163e93264c35",
+                "reference": "ca060f645beeddebedb1885c97bf163e93264c35",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
+                "php": "^5.6 || ^7.0",
                 "phpunit/php-file-iterator": "~1.3",
                 "phpunit/php-text-template": "~1.2",
-                "phpunit/php-token-stream": "~1.3",
-                "sebastian/environment": "^1.3.2",
-                "sebastian/version": "~1.0"
+                "phpunit/php-token-stream": "^1.4.2 || ^2.0",
+                "sebastian/code-unit-reverse-lookup": "~1.0",
+                "sebastian/environment": "^1.3.2 || ^2.0",
+                "sebastian/version": "~1.0|~2.0"
             },
             "require-dev": {
                 "ext-xdebug": ">=2.1.4",
-                "phpunit/phpunit": "~4"
+                "phpunit/phpunit": "^5.4"
             },
             "suggest": {
                 "ext-dom": "*",
-                "ext-xdebug": ">=2.2.1",
+                "ext-xdebug": ">=2.4.0",
                 "ext-xmlwriter": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2.x-dev"
+                    "dev-master": "4.0.x-dev"
                 }
             },
             "autoload": {
@@ -739,20 +782,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06 15:47:00"
+            "time": "2017-02-23T07:38:02+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.1",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0"
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
                 "shasum": ""
             },
             "require": {
@@ -786,7 +829,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2015-06-21 13:08:43"
+            "time": "2016-10-03T07:40:28+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -827,7 +870,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -871,20 +914,20 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2016-05-12 18:03:57"
+            "time": "2016-05-12T18:03:57+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.8",
+            "version": "1.4.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da"
+                "reference": "284fb0679dd25fb5ffb56dad92c72860c0a22f1b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
-                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/284fb0679dd25fb5ffb56dad92c72860c0a22f1b",
+                "reference": "284fb0679dd25fb5ffb56dad92c72860c0a22f1b",
                 "shasum": ""
             },
             "require": {
@@ -920,44 +963,54 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2015-09-15 10:49:45"
+            "time": "2017-02-23T06:14:45+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.27",
+            "version": "5.7.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c062dddcb68e44b563f66ee319ddae2b5a322a90"
+                "reference": "4906b8faf23e42612182fd212eb6f4c0f2954b57"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c062dddcb68e44b563f66ee319ddae2b5a322a90",
-                "reference": "c062dddcb68e44b563f66ee319ddae2b5a322a90",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/4906b8faf23e42612182fd212eb6f4c0f2954b57",
+                "reference": "4906b8faf23e42612182fd212eb6f4c0f2954b57",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-json": "*",
-                "ext-pcre": "*",
-                "ext-reflection": "*",
-                "ext-spl": "*",
-                "php": ">=5.3.3",
-                "phpspec/prophecy": "^1.3.1",
-                "phpunit/php-code-coverage": "~2.1",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "myclabs/deep-copy": "~1.3",
+                "php": "^5.6 || ^7.0",
+                "phpspec/prophecy": "^1.6.2",
+                "phpunit/php-code-coverage": "^4.0.4",
                 "phpunit/php-file-iterator": "~1.4",
                 "phpunit/php-text-template": "~1.2",
                 "phpunit/php-timer": "^1.0.6",
-                "phpunit/phpunit-mock-objects": "~2.3",
-                "sebastian/comparator": "~1.1",
+                "phpunit/phpunit-mock-objects": "^3.2",
+                "sebastian/comparator": "^1.2.4",
                 "sebastian/diff": "~1.2",
-                "sebastian/environment": "~1.3",
-                "sebastian/exporter": "~1.2",
-                "sebastian/global-state": "~1.0",
-                "sebastian/version": "~1.0",
+                "sebastian/environment": "^1.3.4 || ^2.0",
+                "sebastian/exporter": "~2.0",
+                "sebastian/global-state": "^1.1",
+                "sebastian/object-enumerator": "~2.0",
+                "sebastian/resource-operations": "~1.0",
+                "sebastian/version": "~1.0.3|~2.0",
                 "symfony/yaml": "~2.1|~3.0"
             },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "3.0.2"
+            },
+            "require-dev": {
+                "ext-pdo": "*"
+            },
             "suggest": {
+                "ext-xdebug": "*",
                 "phpunit/php-invoker": "~1.1"
             },
             "bin": [
@@ -966,7 +1019,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.8.x-dev"
+                    "dev-master": "5.7.x-dev"
                 }
             },
             "autoload": {
@@ -992,30 +1045,33 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-07-21 06:48:14"
+            "time": "2017-02-19T07:22:16+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "2.3.8",
+            "version": "3.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983"
+                "reference": "3ab72b65b39b491e0c011e2e09bb2206c2aa8e24"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/ac8e7a3db35738d56ee9a76e78a4e03d97628983",
-                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/3ab72b65b39b491e0c011e2e09bb2206c2aa8e24",
+                "reference": "3ab72b65b39b491e0c011e2e09bb2206c2aa8e24",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
-                "php": ">=5.3.3",
-                "phpunit/php-text-template": "~1.2",
-                "sebastian/exporter": "~1.2"
+                "php": "^5.6 || ^7.0",
+                "phpunit/php-text-template": "^1.2",
+                "sebastian/exporter": "^1.2 || ^2.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^5.4"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -1023,7 +1079,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.3.x-dev"
+                    "dev-master": "3.2.x-dev"
                 }
             },
             "autoload": {
@@ -1048,26 +1104,71 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-10-02 06:51:40"
+            "time": "2016-12-08T20:27:08+00:00"
         },
         {
-            "name": "sebastian/comparator",
-            "version": "1.2.0",
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22"
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "c36f5e7cfce482fde5bf8d10d41a53591e0198fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/937efb279bd37a375bcadf584dec0726f84dbf22",
-                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/c36f5e7cfce482fde5bf8d10d41a53591e0198fe",
+                "reference": "c36f5e7cfce482fde5bf8d10d41a53591e0198fe",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "time": "2016-02-13T06:45:14+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "1.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
+                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3",
                 "sebastian/diff": "~1.2",
-                "sebastian/exporter": "~1.2"
+                "sebastian/exporter": "~1.2 || ~2.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "~4.4"
@@ -1112,7 +1213,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2015-07-26 15:48:44"
+            "time": "2017-01-29T09:50:25+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -1164,32 +1265,32 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08 07:14:41"
+            "time": "2015-12-08T07:14:41+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "1.3.8",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea"
+                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/be2c607e43ce4c89ecd60e75c6a85c126e754aea",
-                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
+                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8 || ^5.0"
+                "phpunit/phpunit": "^5.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1214,25 +1315,25 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-08-18 05:49:44"
+            "time": "2016-11-26T07:53:53+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "1.2.2",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4"
+                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/42c4c2eec485ee3e159ec9884f95b431287edde4",
-                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
+                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3",
-                "sebastian/recursion-context": "~1.0"
+                "sebastian/recursion-context": "~2.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
@@ -1241,7 +1342,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1281,7 +1382,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-06-17 09:04:28"
+            "time": "2016-11-19T08:54:04+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -1332,20 +1433,66 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12 03:26:01"
+            "time": "2015-10-12T03:26:01+00:00"
         },
         {
-            "name": "sebastian/recursion-context",
-            "version": "1.0.2",
+            "name": "sebastian/object-enumerator",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "913401df809e99e4f47b27cdd781f4a258d58791"
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/913401df809e99e4f47b27cdd781f4a258d58791",
-                "reference": "913401df809e99e4f47b27cdd781f4a258d58791",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/1311872ac850040a79c3c058bea3e22d0f09cbb7",
+                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "sebastian/recursion-context": "~2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "time": "2017-02-18T15:18:39+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/2c3ba150cbec723aa057506e73a8d33bdb286c9a",
+                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a",
                 "shasum": ""
             },
             "require": {
@@ -1357,7 +1504,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1385,23 +1532,73 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-11-11 19:50:13"
+            "time": "2016-11-19T07:33:16+00:00"
         },
         {
-            "name": "sebastian/version",
-            "version": "1.0.6",
+            "name": "sebastian/resource-operations",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6"
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
-                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
                 "shasum": ""
             },
+            "require": {
+                "php": ">=5.6.0"
+            },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "time": "2015-07-28T20:34:47+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -1420,29 +1617,35 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21 13:59:46"
+            "time": "2016-10-03T07:35:21+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.1.4",
+            "version": "v3.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "f291ed25eb1435bddbe8a96caaef16469c2a092d"
+                "reference": "9724c684646fcb5387d579b4bfaa63ee0b0c64c8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/f291ed25eb1435bddbe8a96caaef16469c2a092d",
-                "reference": "f291ed25eb1435bddbe8a96caaef16469c2a092d",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/9724c684646fcb5387d579b4bfaa63ee0b0c64c8",
+                "reference": "9724c684646fcb5387d579b4bfaa63ee0b0c64c8",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.5.9"
             },
+            "require-dev": {
+                "symfony/console": "~2.8|~3.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
+            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -1469,24 +1672,24 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-02 02:12:52"
+            "time": "2017-02-16T22:46:52+00:00"
         },
         {
             "name": "webmozart/assert",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308"
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/bb2d123231c095735130cc8f6d31385a44c7b308",
-                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3|^7.0"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.6",
@@ -1495,7 +1698,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "1.3-dev"
                 }
             },
             "autoload": {
@@ -1519,7 +1722,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-08-09 15:02:57"
+            "time": "2016-11-23T20:04:58+00:00"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,39 +4,47 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "9b204fb4a7fc5c54a05ee4697272cef4",
+    "content-hash": "0d355b471209f38e044b06e6594813db",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.0.0",
+            "version": "3.31.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "4018c8f14a9e53003bb0417fa859c6a7ad57b53b"
+                "reference": "9829a8183016df800110148b467179d67c434f90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/4018c8f14a9e53003bb0417fa859c6a7ad57b53b",
-                "reference": "4018c8f14a9e53003bb0417fa859c6a7ad57b53b",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/9829a8183016df800110148b467179d67c434f90",
+                "reference": "9829a8183016df800110148b467179d67c434f90",
                 "shasum": ""
             },
             "require": {
-                "guzzlehttp/guzzle": "^5.3 || ^6.0.1",
-                "guzzlehttp/promises": "^1.0.0",
-                "guzzlehttp/psr7": "^1.0.0",
-                "mtdowling/jmespath.php": "^2.2",
+                "guzzlehttp/guzzle": "^5.3.1|^6.2.1",
+                "guzzlehttp/promises": "~1.0",
+                "guzzlehttp/psr7": "^1.4.1",
+                "mtdowling/jmespath.php": "~2.2",
                 "php": ">=5.5"
             },
             "require-dev": {
+                "andrewsville/php-token-reflection": "^1.4",
+                "aws/aws-php-sns-message-validator": "~1.0",
+                "behat/behat": "~3.0",
+                "doctrine/cache": "~1.4",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-openssl": "*",
                 "ext-pcre": "*",
                 "ext-simplexml": "*",
                 "ext-spl": "*",
-                "phpunit/phpunit": "^4.0"
+                "nette/neon": "^2.3",
+                "phpunit/phpunit": "^4.8.35|^5.4.0",
+                "psr/cache": "^1.0"
             },
             "suggest": {
+                "aws/aws-php-sns-message-validator": "To validate incoming SNS notifications",
+                "doctrine/cache": "To use the DoctrineCacheAdapter",
                 "ext-curl": "To send requests using cURL",
                 "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages"
             },
@@ -76,7 +84,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2015-05-27T20:07:42+00:00"
+            "time": "2017-07-20T22:22:05+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -261,21 +269,21 @@
         },
         {
             "name": "maennchen/zipstream-php",
-            "version": "0.3.1",
+            "version": "v0.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/maennchen/ZipStream-PHP.git",
-                "reference": "c492ddf4abcb0f6bed287faae35ebe77be7b690f"
+                "reference": "89e0cdb3c9ecabef4da988852003781a7802afb7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/maennchen/ZipStream-PHP/zipball/c492ddf4abcb0f6bed287faae35ebe77be7b690f",
-                "reference": "c492ddf4abcb0f6bed287faae35ebe77be7b690f",
+                "url": "https://api.github.com/repos/maennchen/ZipStream-PHP/zipball/89e0cdb3c9ecabef4da988852003781a7802afb7",
+                "reference": "89e0cdb3c9ecabef4da988852003781a7802afb7",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "php": ">= 5.3"
+                "php": ">= 5.6"
             },
             "require-dev": {
                 "phpunit/phpunit": "4.3.*"
@@ -309,7 +317,7 @@
                 "stream",
                 "zip"
             ],
-            "time": "2016-02-27T22:32:42+00:00"
+            "time": "2016-09-13T10:29:17+00:00"
         },
         {
             "name": "mtdowling/jmespath.php",

--- a/composer.lock
+++ b/composer.lock
@@ -4,47 +4,39 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "7450bd80eb67c87de316c996fc022cb8",
+    "content-hash": "9b204fb4a7fc5c54a05ee4697272cef4",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.22.10",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "b6b5fa3c8c1b34db822e95fa764de01869493ebe"
+                "reference": "4018c8f14a9e53003bb0417fa859c6a7ad57b53b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/b6b5fa3c8c1b34db822e95fa764de01869493ebe",
-                "reference": "b6b5fa3c8c1b34db822e95fa764de01869493ebe",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/4018c8f14a9e53003bb0417fa859c6a7ad57b53b",
+                "reference": "4018c8f14a9e53003bb0417fa859c6a7ad57b53b",
                 "shasum": ""
             },
             "require": {
-                "guzzlehttp/guzzle": "^5.3.1|^6.2.1",
-                "guzzlehttp/promises": "~1.0",
-                "guzzlehttp/psr7": "~1.3.1",
-                "mtdowling/jmespath.php": "~2.2",
+                "guzzlehttp/guzzle": "^5.3 || ^6.0.1",
+                "guzzlehttp/promises": "^1.0.0",
+                "guzzlehttp/psr7": "^1.0.0",
+                "mtdowling/jmespath.php": "^2.2",
                 "php": ">=5.5"
             },
             "require-dev": {
-                "andrewsville/php-token-reflection": "^1.4",
-                "aws/aws-php-sns-message-validator": "~1.0",
-                "behat/behat": "~3.0",
-                "doctrine/cache": "~1.4",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-openssl": "*",
                 "ext-pcre": "*",
                 "ext-simplexml": "*",
                 "ext-spl": "*",
-                "nette/neon": "^2.3",
-                "phpunit/phpunit": "~4.0|~5.0",
-                "psr/cache": "^1.0"
+                "phpunit/phpunit": "^4.0"
             },
             "suggest": {
-                "aws/aws-php-sns-message-validator": "To validate incoming SNS notifications",
-                "doctrine/cache": "To use the DoctrineCacheAdapter",
                 "ext-curl": "To send requests using cURL",
                 "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages"
             },
@@ -84,31 +76,34 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2017-02-24T00:41:00+00:00"
+            "time": "2015-05-27T20:07:42+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "6.2.2",
+            "version": "6.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "ebf29dee597f02f09f4d5bbecc68230ea9b08f60"
+                "reference": "f4db5a78a5ea468d4831de7f0bf9d9415e348699"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/ebf29dee597f02f09f4d5bbecc68230ea9b08f60",
-                "reference": "ebf29dee597f02f09f4d5bbecc68230ea9b08f60",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/f4db5a78a5ea468d4831de7f0bf9d9415e348699",
+                "reference": "f4db5a78a5ea468d4831de7f0bf9d9415e348699",
                 "shasum": ""
             },
             "require": {
                 "guzzlehttp/promises": "^1.0",
-                "guzzlehttp/psr7": "^1.3.1",
+                "guzzlehttp/psr7": "^1.4",
                 "php": ">=5.5"
             },
             "require-dev": {
                 "ext-curl": "*",
-                "phpunit/phpunit": "^4.0",
+                "phpunit/phpunit": "^4.0 || ^5.0",
                 "psr/log": "^1.0"
+            },
+            "suggest": {
+                "psr/log": "Required for using the Log middleware"
             },
             "type": "library",
             "extra": {
@@ -146,7 +141,7 @@
                 "rest",
                 "web service"
             ],
-            "time": "2016-10-08T15:01:37+00:00"
+            "time": "2017-06-22T18:50:49+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -201,16 +196,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "1.3.1",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "5c6447c9df362e8f8093bda8f5d8873fe5c7f65b"
+                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/5c6447c9df362e8f8093bda8f5d8873fe5c7f65b",
-                "reference": "5c6447c9df362e8f8093bda8f5d8873fe5c7f65b",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
+                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
                 "shasum": ""
             },
             "require": {
@@ -246,34 +241,41 @@
                     "name": "Michael Dowling",
                     "email": "mtdowling@gmail.com",
                     "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "homepage": "https://github.com/Tobion"
                 }
             ],
-            "description": "PSR-7 message implementation",
+            "description": "PSR-7 message implementation that also provides common utility methods",
             "keywords": [
                 "http",
                 "message",
+                "request",
+                "response",
                 "stream",
-                "uri"
+                "uri",
+                "url"
             ],
-            "time": "2016-06-24T23:00:38+00:00"
+            "time": "2017-03-20T17:10:46+00:00"
         },
         {
             "name": "maennchen/zipstream-php",
-            "version": "v0.4.1",
+            "version": "0.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/maennchen/ZipStream-PHP.git",
-                "reference": "89e0cdb3c9ecabef4da988852003781a7802afb7"
+                "reference": "c492ddf4abcb0f6bed287faae35ebe77be7b690f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/maennchen/ZipStream-PHP/zipball/89e0cdb3c9ecabef4da988852003781a7802afb7",
-                "reference": "89e0cdb3c9ecabef4da988852003781a7802afb7",
+                "url": "https://api.github.com/repos/maennchen/ZipStream-PHP/zipball/c492ddf4abcb0f6bed287faae35ebe77be7b690f",
+                "reference": "c492ddf4abcb0f6bed287faae35ebe77be7b690f",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "php": ">= 5.6"
+                "php": ">= 5.3"
             },
             "require-dev": {
                 "phpunit/phpunit": "4.3.*"
@@ -307,7 +309,7 @@
                 "stream",
                 "zip"
             ],
-            "time": "2016-09-13T10:29:17+00:00"
+            "time": "2016-02-27T22:32:42+00:00"
         },
         {
             "name": "mtdowling/jmespath.php",
@@ -418,32 +420,32 @@
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.0.5",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
+                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
+                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3,<8.0-DEV"
+                "php": "^7.1"
             },
             "require-dev": {
                 "athletic/athletic": "~0.1.8",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~2.0"
+                "phpunit/phpunit": "^6.2.3",
+                "squizlabs/php_codesniffer": "^3.0.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -468,20 +470,20 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14T21:17:01+00:00"
+            "time": "2017-07-22T11:58:36+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.6.0",
+            "version": "1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "5a5a9fc8025a08d8919be87d6884d5a92520cefe"
+                "reference": "8e6e04167378abf1ddb4d3522d8755c5fd90d102"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/5a5a9fc8025a08d8919be87d6884d5a92520cefe",
-                "reference": "5a5a9fc8025a08d8919be87d6884d5a92520cefe",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/8e6e04167378abf1ddb4d3522d8755c5fd90d102",
+                "reference": "8e6e04167378abf1ddb4d3522d8755c5fd90d102",
                 "shasum": ""
             },
             "require": {
@@ -510,7 +512,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2017-01-26T22:05:40+00:00"
+            "time": "2017-04-12T18:52:22+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -568,22 +570,22 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "3.1.1",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e"
+                "reference": "46f7e8bb075036c92695b15a1ddb6971c751e585"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/8331b5efe816ae05461b7ca1e721c01b46bafb3e",
-                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/46f7e8bb075036c92695b15a1ddb6971c751e585",
+                "reference": "46f7e8bb075036c92695b15a1ddb6971c751e585",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.5",
                 "phpdocumentor/reflection-common": "^1.0@dev",
-                "phpdocumentor/type-resolver": "^0.2.0",
+                "phpdocumentor/type-resolver": "^0.4.0",
                 "webmozart/assert": "^1.0"
             },
             "require-dev": {
@@ -609,24 +611,24 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2016-09-30T07:12:33+00:00"
+            "time": "2017-07-15T11:38:20+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "0.2.1",
+            "version": "0.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb"
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
-                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5",
+                "php": "^5.5 || ^7.0",
                 "phpdocumentor/reflection-common": "^1.0"
             },
             "require-dev": {
@@ -656,31 +658,31 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-11-25T06:54:22+00:00"
+            "time": "2017-07-14T14:27:02+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.6.2",
+            "version": "v1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "6c52c2722f8460122f96f86346600e1077ce22cb"
+                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/6c52c2722f8460122f96f86346600e1077ce22cb",
-                "reference": "6c52c2722f8460122f96f86346600e1077ce22cb",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/93d39f1f7f9326d746203c7c056f300f7f126073",
+                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
                 "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
-                "sebastian/comparator": "^1.1",
-                "sebastian/recursion-context": "^1.0|^2.0"
+                "sebastian/comparator": "^1.1|^2.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^2.0",
+                "phpspec/phpspec": "^2.5|^3.2",
                 "phpunit/phpunit": "^4.8 || ^5.6.5"
             },
             "type": "library",
@@ -719,39 +721,39 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-11-21T14:58:47+00:00"
+            "time": "2017-03-02T20:05:34+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "4.0.6",
+            "version": "4.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "ca060f645beeddebedb1885c97bf163e93264c35"
+                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ca060f645beeddebedb1885c97bf163e93264c35",
-                "reference": "ca060f645beeddebedb1885c97bf163e93264c35",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
+                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
                 "shasum": ""
             },
             "require": {
+                "ext-dom": "*",
+                "ext-xmlwriter": "*",
                 "php": "^5.6 || ^7.0",
-                "phpunit/php-file-iterator": "~1.3",
-                "phpunit/php-text-template": "~1.2",
+                "phpunit/php-file-iterator": "^1.3",
+                "phpunit/php-text-template": "^1.2",
                 "phpunit/php-token-stream": "^1.4.2 || ^2.0",
-                "sebastian/code-unit-reverse-lookup": "~1.0",
+                "sebastian/code-unit-reverse-lookup": "^1.0",
                 "sebastian/environment": "^1.3.2 || ^2.0",
-                "sebastian/version": "~1.0|~2.0"
+                "sebastian/version": "^1.0 || ^2.0"
             },
             "require-dev": {
-                "ext-xdebug": ">=2.1.4",
-                "phpunit/phpunit": "^5.4"
+                "ext-xdebug": "^2.1.4",
+                "phpunit/phpunit": "^5.7"
             },
             "suggest": {
-                "ext-dom": "*",
-                "ext-xdebug": ">=2.4.0",
-                "ext-xmlwriter": "*"
+                "ext-xdebug": "^2.5.1"
             },
             "type": "library",
             "extra": {
@@ -782,7 +784,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-02-23T07:38:02+00:00"
+            "time": "2017-04-02T07:44:40+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -874,25 +876,30 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.8",
+            "version": "1.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260"
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/38e9124049cf1a164f1e4537caf19c99bf1eb260",
-                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4|~5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -914,20 +921,20 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2016-05-12T18:03:57+00:00"
+            "time": "2017-02-26T11:10:40+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.10",
+            "version": "1.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "284fb0679dd25fb5ffb56dad92c72860c0a22f1b"
+                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/284fb0679dd25fb5ffb56dad92c72860c0a22f1b",
-                "reference": "284fb0679dd25fb5ffb56dad92c72860c0a22f1b",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/e03f8f67534427a787e21a385a67ec3ca6978ea7",
+                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7",
                 "shasum": ""
             },
             "require": {
@@ -963,20 +970,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-02-23T06:14:45+00:00"
+            "time": "2017-02-27T10:12:30+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.7.14",
+            "version": "5.7.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "4906b8faf23e42612182fd212eb6f4c0f2954b57"
+                "reference": "3b91adfb64264ddec5a2dee9851f354aa66327db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/4906b8faf23e42612182fd212eb6f4c0f2954b57",
-                "reference": "4906b8faf23e42612182fd212eb6f4c0f2954b57",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3b91adfb64264ddec5a2dee9851f354aa66327db",
+                "reference": "3b91adfb64264ddec5a2dee9851f354aa66327db",
                 "shasum": ""
             },
             "require": {
@@ -994,7 +1001,7 @@
                 "phpunit/php-timer": "^1.0.6",
                 "phpunit/phpunit-mock-objects": "^3.2",
                 "sebastian/comparator": "^1.2.4",
-                "sebastian/diff": "~1.2",
+                "sebastian/diff": "^1.4.3",
                 "sebastian/environment": "^1.3.4 || ^2.0",
                 "sebastian/exporter": "~2.0",
                 "sebastian/global-state": "^1.1",
@@ -1045,20 +1052,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-02-19T07:22:16+00:00"
+            "time": "2017-06-21T08:11:54+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "3.4.3",
+            "version": "3.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "3ab72b65b39b491e0c011e2e09bb2206c2aa8e24"
+                "reference": "a23b761686d50a560cc56233b9ecf49597cc9118"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/3ab72b65b39b491e0c011e2e09bb2206c2aa8e24",
-                "reference": "3ab72b65b39b491e0c011e2e09bb2206c2aa8e24",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/a23b761686d50a560cc56233b9ecf49597cc9118",
+                "reference": "a23b761686d50a560cc56233b9ecf49597cc9118",
                 "shasum": ""
             },
             "require": {
@@ -1104,27 +1111,27 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2016-12-08T20:27:08+00:00"
+            "time": "2017-06-30T09:13:00+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "c36f5e7cfce482fde5bf8d10d41a53591e0198fe"
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/c36f5e7cfce482fde5bf8d10d41a53591e0198fe",
-                "reference": "c36f5e7cfce482fde5bf8d10d41a53591e0198fe",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~5"
+                "phpunit/phpunit": "^5.7 || ^6.0"
             },
             "type": "library",
             "extra": {
@@ -1149,7 +1156,7 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2016-02-13T06:45:14+00:00"
+            "time": "2017-03-04T06:30:41+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -1217,23 +1224,23 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "1.4.1",
+            "version": "1.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e"
+                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/13edfd8706462032c2f52b4b862974dd46b71c9e",
-                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7f066a26a962dbe58ddea9f72a4e82874a3975a4",
+                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.8"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
             },
             "type": "library",
             "extra": {
@@ -1265,7 +1272,7 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08T07:14:41+00:00"
+            "time": "2017-05-22T07:24:03+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -1621,16 +1628,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.2.4",
+            "version": "v3.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "9724c684646fcb5387d579b4bfaa63ee0b0c64c8"
+                "reference": "1f93a8d19b8241617f5074a123e282575b821df8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/9724c684646fcb5387d579b4bfaa63ee0b0c64c8",
-                "reference": "9724c684646fcb5387d579b4bfaa63ee0b0c64c8",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/1f93a8d19b8241617f5074a123e282575b821df8",
+                "reference": "1f93a8d19b8241617f5074a123e282575b821df8",
                 "shasum": ""
             },
             "require": {
@@ -1645,7 +1652,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-master": "3.3-dev"
                 }
             },
             "autoload": {
@@ -1672,7 +1679,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-02-16T22:46:52+00:00"
+            "time": "2017-06-15T12:58:50+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -1731,7 +1738,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.3.3"
+        "php": ">=7.0"
     },
     "platform-dev": []
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,53 +1,67 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "61193cfede295ced47f09fdb2caf86f3",
+    "hash": "26177f7c54cd4dd3dbd6de0809901b47",
+    "content-hash": "3efa5940c65bdda57118f84129e80927",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "2.7.21",
+            "version": "3.19.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "9dc3bb6dd6e16a7ed2f6fab73c2ee385145e26c0"
+                "reference": "f67bc37fa4b76d85423052eae2a9577aab99adc1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/9dc3bb6dd6e16a7ed2f6fab73c2ee385145e26c0",
-                "reference": "9dc3bb6dd6e16a7ed2f6fab73c2ee385145e26c0",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/f67bc37fa4b76d85423052eae2a9577aab99adc1",
+                "reference": "f67bc37fa4b76d85423052eae2a9577aab99adc1",
                 "shasum": ""
             },
             "require": {
-                "guzzle/guzzle": "~3.7",
-                "php": ">=5.3.3"
+                "guzzlehttp/guzzle": "^5.3.1|^6.2.1",
+                "guzzlehttp/promises": "~1.0",
+                "guzzlehttp/psr7": "~1.3.1",
+                "mtdowling/jmespath.php": "~2.2",
+                "php": ">=5.5"
             },
             "require-dev": {
-                "doctrine/cache": "~1.0",
+                "andrewsville/php-token-reflection": "^1.4",
+                "aws/aws-php-sns-message-validator": "~1.0",
+                "behat/behat": "~3.0",
+                "doctrine/cache": "~1.4",
+                "ext-dom": "*",
+                "ext-json": "*",
                 "ext-openssl": "*",
-                "monolog/monolog": "~1.4",
-                "phpunit/phpunit": "~4.0",
-                "symfony/yaml": "~2.1"
+                "ext-pcre": "*",
+                "ext-simplexml": "*",
+                "ext-spl": "*",
+                "nette/neon": "^2.3",
+                "phpunit/phpunit": "~4.0|~5.0",
+                "psr/cache": "^1.0"
             },
             "suggest": {
-                "doctrine/cache": "Adds support for caching of credentials and responses",
-                "ext-apc": "Allows service description opcode caching, request and response caching, and credentials caching",
-                "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages",
-                "monolog/monolog": "Adds support for logging HTTP requests and responses",
-                "symfony/yaml": "Eases the ability to write manifests for creating jobs in AWS Import/Export"
+                "aws/aws-php-sns-message-validator": "To validate incoming SNS notifications",
+                "doctrine/cache": "To use the DoctrineCacheAdapter",
+                "ext-curl": "To send requests using cURL",
+                "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Aws": "src/"
-                }
+                "psr-4": {
+                    "Aws\\": "src/"
+                },
+                "files": [
+                    "src/functions.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -71,70 +85,44 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2015-03-05 00:07:56"
+            "time": "2016-09-01 21:37:32"
         },
         {
-            "name": "guzzle/guzzle",
-            "version": "v3.9.2",
+            "name": "guzzlehttp/guzzle",
+            "version": "6.2.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/guzzle/guzzle3.git",
-                "reference": "54991459675c1a2924122afbb0e5609ade581155"
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "3f808fba627f2c5b69e2501217bf31af349c1427"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle3/zipball/54991459675c1a2924122afbb0e5609ade581155",
-                "reference": "54991459675c1a2924122afbb0e5609ade581155",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/3f808fba627f2c5b69e2501217bf31af349c1427",
+                "reference": "3f808fba627f2c5b69e2501217bf31af349c1427",
                 "shasum": ""
             },
             "require": {
-                "ext-curl": "*",
-                "php": ">=5.3.3",
-                "symfony/event-dispatcher": "~2.1"
-            },
-            "replace": {
-                "guzzle/batch": "self.version",
-                "guzzle/cache": "self.version",
-                "guzzle/common": "self.version",
-                "guzzle/http": "self.version",
-                "guzzle/inflection": "self.version",
-                "guzzle/iterator": "self.version",
-                "guzzle/log": "self.version",
-                "guzzle/parser": "self.version",
-                "guzzle/plugin": "self.version",
-                "guzzle/plugin-async": "self.version",
-                "guzzle/plugin-backoff": "self.version",
-                "guzzle/plugin-cache": "self.version",
-                "guzzle/plugin-cookie": "self.version",
-                "guzzle/plugin-curlauth": "self.version",
-                "guzzle/plugin-error-response": "self.version",
-                "guzzle/plugin-history": "self.version",
-                "guzzle/plugin-log": "self.version",
-                "guzzle/plugin-md5": "self.version",
-                "guzzle/plugin-mock": "self.version",
-                "guzzle/plugin-oauth": "self.version",
-                "guzzle/service": "self.version",
-                "guzzle/stream": "self.version"
+                "guzzlehttp/promises": "^1.0",
+                "guzzlehttp/psr7": "^1.3.1",
+                "php": ">=5.5"
             },
             "require-dev": {
-                "doctrine/cache": "~1.3",
-                "monolog/monolog": "~1.0",
-                "phpunit/phpunit": "3.7.*",
-                "psr/log": "~1.0",
-                "symfony/class-loader": "~2.1",
-                "zendframework/zend-cache": "2.*,<2.3",
-                "zendframework/zend-log": "2.*,<2.3"
+                "ext-curl": "*",
+                "phpunit/phpunit": "^4.0",
+                "psr/log": "^1.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.9-dev"
+                    "dev-master": "6.2-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Guzzle": "src/",
-                    "Guzzle\\Tests": "tests/"
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -146,13 +134,9 @@
                     "name": "Michael Dowling",
                     "email": "mtdowling@gmail.com",
                     "homepage": "https://github.com/mtdowling"
-                },
-                {
-                    "name": "Guzzle Community",
-                    "homepage": "https://github.com/guzzle/guzzle/contributors"
                 }
             ],
-            "description": "Guzzle is a PHP HTTP client library and framework for building RESTful web service clients",
+            "description": "Guzzle is a PHP HTTP client library",
             "homepage": "http://guzzlephp.org/",
             "keywords": [
                 "client",
@@ -163,23 +147,133 @@
                 "rest",
                 "web service"
             ],
-            "time": "2014-08-11 04:32:36"
+            "time": "2016-07-15 17:22:37"
         },
         {
-            "name": "maennchen/zipstream-php",
-            "version": "0.3.0",
+            "name": "guzzlehttp/promises",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/maennchen/ZipStream-PHP.git",
-                "reference": "6ef77339a768f5066310a1c908cd50cf6a5b05d7"
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "c10d860e2a9595f8883527fa0021c7da9e65f579"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/maennchen/ZipStream-PHP/zipball/6ef77339a768f5066310a1c908cd50cf6a5b05d7",
-                "reference": "6ef77339a768f5066310a1c908cd50cf6a5b05d7",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/c10d860e2a9595f8883527fa0021c7da9e65f579",
+                "reference": "c10d860e2a9595f8883527fa0021c7da9e65f579",
                 "shasum": ""
             },
             "require": {
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "time": "2016-05-18 16:56:05"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "5c6447c9df362e8f8093bda8f5d8873fe5c7f65b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/5c6447c9df362e8f8093bda8f5d8873fe5c7f65b",
+                "reference": "5c6447c9df362e8f8093bda8f5d8873fe5c7f65b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "psr/http-message": "~1.0"
+            },
+            "provide": {
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "PSR-7 message implementation",
+            "keywords": [
+                "http",
+                "message",
+                "stream",
+                "uri"
+            ],
+            "time": "2016-06-24 23:00:38"
+        },
+        {
+            "name": "maennchen/zipstream-php",
+            "version": "0.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/maennchen/ZipStream-PHP.git",
+                "reference": "c492ddf4abcb0f6bed287faae35ebe77be7b690f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/maennchen/ZipStream-PHP/zipball/c492ddf4abcb0f6bed287faae35ebe77be7b690f",
+                "reference": "c492ddf4abcb0f6bed287faae35ebe77be7b690f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
                 "php": ">= 5.3"
             },
             "require-dev": {
@@ -214,46 +308,89 @@
                 "stream",
                 "zip"
             ],
-            "time": "2015-01-15 19:43:13"
+            "time": "2016-02-27 22:32:42"
         },
         {
-            "name": "symfony/event-dispatcher",
-            "version": "v2.6.4",
-            "target-dir": "Symfony/Component/EventDispatcher",
+            "name": "mtdowling/jmespath.php",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/EventDispatcher.git",
-                "reference": "f75989f3ab2743a82fe0b03ded2598a2b1546813"
+                "url": "https://github.com/jmespath/jmespath.php.git",
+                "reference": "192f93e43c2c97acde7694993ab171b3de284093"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/f75989f3ab2743a82fe0b03ded2598a2b1546813",
-                "reference": "f75989f3ab2743a82fe0b03ded2598a2b1546813",
+                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/192f93e43c2c97acde7694993ab171b3de284093",
+                "reference": "192f93e43c2c97acde7694993ab171b3de284093",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=5.4.0"
             },
             "require-dev": {
-                "psr/log": "~1.0",
-                "symfony/config": "~2.0,>=2.0.5",
-                "symfony/dependency-injection": "~2.6",
-                "symfony/expression-language": "~2.6",
-                "symfony/stopwatch": "~2.3"
+                "phpunit/phpunit": "~4.0"
             },
-            "suggest": {
-                "symfony/dependency-injection": "",
-                "symfony/http-kernel": ""
+            "bin": [
+                "bin/jp.php"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "JmesPath\\": "src/"
+                },
+                "files": [
+                    "src/JmesPath.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Declaratively specify how to extract elements from a JSON document",
+            "keywords": [
+                "json",
+                "jsonpath"
+            ],
+            "time": "2016-01-05 18:25:05"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6-dev"
+                    "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Symfony\\Component\\EventDispatcher\\": ""
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -262,32 +399,36 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
                 }
             ],
-            "description": "Symfony EventDispatcher Component",
-            "homepage": "http://symfony.com",
-            "time": "2015-02-01 16:10:57"
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2016-08-06 14:39:51"
         }
     ],
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.0.4",
+            "version": "1.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "f976e5de371104877ebc89bd8fecb0019ed9c119"
+                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/f976e5de371104877ebc89bd8fecb0019ed9c119",
-                "reference": "f976e5de371104877ebc89bd8fecb0019ed9c119",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
                 "shasum": ""
             },
             "require": {
@@ -298,7 +439,7 @@
                 "ext-pdo": "*",
                 "ext-phar": "*",
                 "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "2.0.*@ALPHA"
+                "squizlabs/php_codesniffer": "~2.0"
             },
             "type": "library",
             "extra": {
@@ -307,8 +448,8 @@
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Doctrine\\Instantiator\\": "src"
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -328,41 +469,90 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2014-10-13 12:58:55"
+            "time": "2015-06-14 21:17:01"
         },
         {
-            "name": "phpdocumentor/reflection-docblock",
-            "version": "2.0.4",
+            "name": "phpdocumentor/reflection-common",
+            "version": "1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "d68dbdc53dc358a816f00b300704702b2eaff7b8"
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/d68dbdc53dc358a816f00b300704702b2eaff7b8",
-                "reference": "d68dbdc53dc358a816f00b300704702b2eaff7b8",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
+                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=5.5"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
-            },
-            "suggest": {
-                "dflydev/markdown": "~1.0",
-                "erusev/parsedown": "~1.0"
+                "phpunit/phpunit": "^4.6"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "phpDocumentor": [
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "time": "2015-12-27 11:43:31"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "9270140b940ff02e58ec577c237274e92cd40cdd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/9270140b940ff02e58ec577c237274e92cd40cdd",
+                "reference": "9270140b940ff02e58ec577c237274e92cd40cdd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5",
+                "phpdocumentor/reflection-common": "^1.0@dev",
+                "phpdocumentor/type-resolver": "^0.2.0",
+                "webmozart/assert": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^4.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
                         "src/"
                     ]
                 }
@@ -374,36 +564,87 @@
             "authors": [
                 {
                     "name": "Mike van Riel",
-                    "email": "mike.vanriel@naenius.com"
+                    "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2015-02-03 12:10:50"
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "time": "2016-06-10 09:48:41"
         },
         {
-            "name": "phpspec/prophecy",
-            "version": "v1.3.1",
+            "name": "phpdocumentor/type-resolver",
+            "version": "0.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "9ca52329bcdd1500de24427542577ebf3fc2f1c9"
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/9ca52329bcdd1500de24427542577ebf3fc2f1c9",
-                "reference": "9ca52329bcdd1500de24427542577ebf3fc2f1c9",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/b39c7a5b194f9ed7bd0dd345c751007a41862443",
+                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "~1.0,>=1.0.2",
-                "phpdocumentor/reflection-docblock": "~2.0"
+                "php": ">=5.5",
+                "phpdocumentor/reflection-common": "^1.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "~2.0"
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^5.2||^4.8.24"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "time": "2016-06-10 07:14:17"
+        },
+        {
+            "name": "phpspec/prophecy",
+            "version": "v1.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy.git",
+                "reference": "58a8137754bc24b25740d4281399a4a3596058e0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/58a8137754bc24b25740d4281399a4a3596058e0",
+                "reference": "58a8137754bc24b25740d4281399a4a3596058e0",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.2",
+                "php": "^5.3|^7.0",
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
+                "sebastian/comparator": "^1.1",
+                "sebastian/recursion-context": "^1.0"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
                 }
             },
             "autoload": {
@@ -427,7 +668,7 @@
                 }
             ],
             "description": "Highly opinionated mocking framework for PHP 5.3+",
-            "homepage": "http://phpspec.org",
+            "homepage": "https://github.com/phpspec/prophecy",
             "keywords": [
                 "Double",
                 "Dummy",
@@ -436,20 +677,20 @@
                 "spy",
                 "stub"
             ],
-            "time": "2014-11-17 16:23:49"
+            "time": "2016-06-07 08:13:47"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "2.0.15",
+            "version": "2.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "34cc484af1ca149188d0d9e91412191e398e0b67"
+                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/34cc484af1ca149188d0d9e91412191e398e0b67",
-                "reference": "34cc484af1ca149188d0d9e91412191e398e0b67",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/eabf68b476ac7d0f73793aada060f1c1a9bf8979",
+                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979",
                 "shasum": ""
             },
             "require": {
@@ -457,7 +698,7 @@
                 "phpunit/php-file-iterator": "~1.3",
                 "phpunit/php-text-template": "~1.2",
                 "phpunit/php-token-stream": "~1.3",
-                "sebastian/environment": "~1.0",
+                "sebastian/environment": "^1.3.2",
                 "sebastian/version": "~1.0"
             },
             "require-dev": {
@@ -472,7 +713,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "2.2.x-dev"
                 }
             },
             "autoload": {
@@ -498,35 +739,37 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-01-24 10:06:35"
+            "time": "2015-10-06 15:47:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.3.4",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "acd690379117b042d1c8af1fafd61bde001bf6bb"
+                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/acd690379117b042d1c8af1fafd61bde001bf6bb",
-                "reference": "acd690379117b042d1c8af1fafd61bde001bf6bb",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
-                    "File/"
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
-            "include-path": [
-                ""
-            ],
             "license": [
                 "BSD-3-Clause"
             ],
@@ -543,20 +786,20 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2013-10-10 15:34:57"
+            "time": "2015-06-21 13:08:43"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "206dfefc0ffe9cebf65c413e3d0e809c82fbf00a"
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/206dfefc0ffe9cebf65c413e3d0e809c82fbf00a",
-                "reference": "206dfefc0ffe9cebf65c413e3d0e809c82fbf00a",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
                 "shasum": ""
             },
             "require": {
@@ -565,20 +808,17 @@
             "type": "library",
             "autoload": {
                 "classmap": [
-                    "Text/"
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
-            "include-path": [
-                ""
-            ],
             "license": [
                 "BSD-3-Clause"
             ],
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -587,35 +827,35 @@
             "keywords": [
                 "template"
             ],
-            "time": "2014-01-30 17:20:04"
+            "time": "2015-06-21 13:50:34"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.5",
+            "version": "1.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "19689d4354b295ee3d8c54b4f42c3efb69cbc17c"
+                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/19689d4354b295ee3d8c54b4f42c3efb69cbc17c",
-                "reference": "19689d4354b295ee3d8c54b4f42c3efb69cbc17c",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/38e9124049cf1a164f1e4537caf19c99bf1eb260",
+                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
+            "require-dev": {
+                "phpunit/phpunit": "~4|~5"
+            },
             "type": "library",
             "autoload": {
                 "classmap": [
-                    "PHP/"
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
-            "include-path": [
-                ""
-            ],
             "license": [
                 "BSD-3-Clause"
             ],
@@ -631,20 +871,20 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2013-08-02 07:42:54"
+            "time": "2016-05-12 18:03:57"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.0",
+            "version": "1.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "db32c18eba00b121c145575fcbcd4d4d24e6db74"
+                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/db32c18eba00b121c145575fcbcd4d4d24e6db74",
-                "reference": "db32c18eba00b121c145575fcbcd4d4d24e6db74",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
+                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
                 "shasum": ""
             },
             "require": {
@@ -680,20 +920,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2015-01-17 09:51:32"
+            "time": "2015-09-15 10:49:45"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.5.0",
+            "version": "4.8.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "5b578d3865a9128b9c209b011fda6539ec06e7a5"
+                "reference": "c062dddcb68e44b563f66ee319ddae2b5a322a90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/5b578d3865a9128b9c209b011fda6539ec06e7a5",
-                "reference": "5b578d3865a9128b9c209b011fda6539ec06e7a5",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c062dddcb68e44b563f66ee319ddae2b5a322a90",
+                "reference": "c062dddcb68e44b563f66ee319ddae2b5a322a90",
                 "shasum": ""
             },
             "require": {
@@ -703,19 +943,19 @@
                 "ext-reflection": "*",
                 "ext-spl": "*",
                 "php": ">=5.3.3",
-                "phpspec/prophecy": "~1.3.1",
-                "phpunit/php-code-coverage": "~2.0",
-                "phpunit/php-file-iterator": "~1.3.2",
+                "phpspec/prophecy": "^1.3.1",
+                "phpunit/php-code-coverage": "~2.1",
+                "phpunit/php-file-iterator": "~1.4",
                 "phpunit/php-text-template": "~1.2",
-                "phpunit/php-timer": "~1.0.2",
+                "phpunit/php-timer": "^1.0.6",
                 "phpunit/phpunit-mock-objects": "~2.3",
                 "sebastian/comparator": "~1.1",
-                "sebastian/diff": "~1.1",
-                "sebastian/environment": "~1.2",
+                "sebastian/diff": "~1.2",
+                "sebastian/environment": "~1.3",
                 "sebastian/exporter": "~1.2",
                 "sebastian/global-state": "~1.0",
                 "sebastian/version": "~1.0",
-                "symfony/yaml": "~2.0"
+                "symfony/yaml": "~2.1|~3.0"
             },
             "suggest": {
                 "phpunit/php-invoker": "~1.1"
@@ -726,7 +966,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.5.x-dev"
+                    "dev-master": "4.8.x-dev"
                 }
             },
             "autoload": {
@@ -752,29 +992,30 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-02-05 15:51:19"
+            "time": "2016-07-21 06:48:14"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "2.3.0",
+            "version": "2.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "c63d2367247365f688544f0d500af90a11a44c65"
+                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/c63d2367247365f688544f0d500af90a11a44c65",
-                "reference": "c63d2367247365f688544f0d500af90a11a44c65",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/ac8e7a3db35738d56ee9a76e78a4e03d97628983",
+                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "~1.0,>=1.0.1",
+                "doctrine/instantiator": "^1.0.2",
                 "php": ">=5.3.3",
-                "phpunit/php-text-template": "~1.2"
+                "phpunit/php-text-template": "~1.2",
+                "sebastian/exporter": "~1.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.3"
+                "phpunit/phpunit": "~4.4"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -807,20 +1048,20 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2014-10-03 05:12:11"
+            "time": "2015-10-02 06:51:40"
         },
         {
             "name": "sebastian/comparator",
-            "version": "1.1.1",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "1dd8869519a225f7f2b9eb663e225298fade819e"
+                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/1dd8869519a225f7f2b9eb663e225298fade819e",
-                "reference": "1dd8869519a225f7f2b9eb663e225298fade819e",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/937efb279bd37a375bcadf584dec0726f84dbf22",
+                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22",
                 "shasum": ""
             },
             "require": {
@@ -834,7 +1075,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -871,32 +1112,32 @@
                 "compare",
                 "equality"
             ],
-            "time": "2015-01-29 16:28:08"
+            "time": "2015-07-26 15:48:44"
         },
         {
             "name": "sebastian/diff",
-            "version": "1.2.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "5843509fed39dee4b356a306401e9dd1a931fec7"
+                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/5843509fed39dee4b356a306401e9dd1a931fec7",
-                "reference": "5843509fed39dee4b356a306401e9dd1a931fec7",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/13edfd8706462032c2f52b4b862974dd46b71c9e",
+                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "~4.8"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "1.4-dev"
                 }
             },
             "autoload": {
@@ -919,36 +1160,36 @@
                 }
             ],
             "description": "Diff implementation",
-            "homepage": "http://www.github.com/sebastianbergmann/diff",
+            "homepage": "https://github.com/sebastianbergmann/diff",
             "keywords": [
                 "diff"
             ],
-            "time": "2014-08-15 10:29:00"
+            "time": "2015-12-08 07:14:41"
         },
         {
             "name": "sebastian/environment",
-            "version": "1.2.1",
+            "version": "1.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "6e6c71d918088c251b181ba8b3088af4ac336dd7"
+                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6e6c71d918088c251b181ba8b3088af4ac336dd7",
-                "reference": "6e6c71d918088c251b181ba8b3088af4ac336dd7",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/be2c607e43ce4c89ecd60e75c6a85c126e754aea",
+                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.3"
+                "phpunit/phpunit": "^4.8 || ^5.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "1.3.x-dev"
                 }
             },
             "autoload": {
@@ -973,20 +1214,20 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2014-10-25 08:00:45"
+            "time": "2016-08-18 05:49:44"
         },
         {
             "name": "sebastian/exporter",
-            "version": "1.2.0",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "84839970d05254c73cde183a721c7af13aede943"
+                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/84839970d05254c73cde183a721c7af13aede943",
-                "reference": "84839970d05254c73cde183a721c7af13aede943",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/42c4c2eec485ee3e159ec9884f95b431287edde4",
+                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4",
                 "shasum": ""
             },
             "require": {
@@ -994,12 +1235,13 @@
                 "sebastian/recursion-context": "~1.0"
             },
             "require-dev": {
+                "ext-mbstring": "*",
                 "phpunit/phpunit": "~4.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "1.3.x-dev"
                 }
             },
             "autoload": {
@@ -1039,20 +1281,20 @@
                 "export",
                 "exporter"
             ],
-            "time": "2015-01-27 07:23:06"
+            "time": "2016-06-17 09:04:28"
         },
         {
             "name": "sebastian/global-state",
-            "version": "1.0.0",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "c7428acdb62ece0a45e6306f1ae85e1c05b09c01"
+                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/c7428acdb62ece0a45e6306f1ae85e1c05b09c01",
-                "reference": "c7428acdb62ece0a45e6306f1ae85e1c05b09c01",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4",
                 "shasum": ""
             },
             "require": {
@@ -1090,20 +1332,20 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2014-10-06 09:23:50"
+            "time": "2015-10-12 03:26:01"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "1.0.0",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "3989662bbb30a29d20d9faa04a846af79b276252"
+                "reference": "913401df809e99e4f47b27cdd781f4a258d58791"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/3989662bbb30a29d20d9faa04a846af79b276252",
-                "reference": "3989662bbb30a29d20d9faa04a846af79b276252",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/913401df809e99e4f47b27cdd781f4a258d58791",
+                "reference": "913401df809e99e4f47b27cdd781f4a258d58791",
                 "shasum": ""
             },
             "require": {
@@ -1143,20 +1385,20 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-01-24 09:48:32"
+            "time": "2015-11-11 19:50:13"
         },
         {
             "name": "sebastian/version",
-            "version": "1.0.4",
+            "version": "1.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "a77d9123f8e809db3fbdea15038c27a95da4058b"
+                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/a77d9123f8e809db3fbdea15038c27a95da4058b",
-                "reference": "a77d9123f8e809db3fbdea15038c27a95da4058b",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
+                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
                 "shasum": ""
             },
             "type": "library",
@@ -1178,35 +1420,87 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2014-12-15 14:25:24"
+            "time": "2015-06-21 13:59:46"
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.6.4",
-            "target-dir": "Symfony/Component/Yaml",
+            "version": "v3.1.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Yaml.git",
-                "reference": "60ed7751671113cf1ee7d7778e691642c2e9acd8"
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "f291ed25eb1435bddbe8a96caaef16469c2a092d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Yaml/zipball/60ed7751671113cf1ee7d7778e691642c2e9acd8",
-                "reference": "60ed7751671113cf1ee7d7778e691642c2e9acd8",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/f291ed25eb1435bddbe8a96caaef16469c2a092d",
+                "reference": "f291ed25eb1435bddbe8a96caaef16469c2a092d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=5.5.9"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
+                "psr-4": {
                     "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-09-02 02:12:52"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/bb2d123231c095735130cc8f6d31385a44c7b308",
+                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3|^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1215,17 +1509,17 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
                 }
             ],
-            "description": "Symfony Yaml Component",
-            "homepage": "http://symfony.com",
-            "time": "2015-01-25 04:39:26"
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "time": "2016-08-09 15:02:57"
         }
     ],
     "aliases": [],

--- a/examples/AwsZipStreamServiceProvider.php
+++ b/examples/AwsZipStreamServiceProvider.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use limenet\S3BucketStreamZip\S3BucketStreamZip;
+
+class AWSZipStreamServiceProvider extends ServiceProvider
+{
+    /**
+     * Indicates if loading of the provider is deferred.
+     *
+     * @var bool
+     */
+    protected $defer = true;
+
+    /**
+     * Bootstrap the application services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+
+    }
+
+    /**
+     * Register the application services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->app->bind(S3BucketStreamZip::class, function($_) {
+            return new S3BucketStreamZip([
+                'key'     => config('services.s3.key'),
+                'secret'  => config('services.s3.secret'),
+                'region'  => config('services.s3.region'),
+                'version' => config('services.s3.version'),
+            ]);
+        });
+    }
+
+    /**
+     * Get the services provided by the provider.
+     *
+     * @return array
+     */
+    public function provides()
+    {
+        return [S3BucketStreamZip::class];
+    }
+}

--- a/examples/AwsZipStreamServiceProvider.php
+++ b/examples/AwsZipStreamServiceProvider.php
@@ -5,7 +5,7 @@ namespace App\Providers;
 use Illuminate\Support\ServiceProvider;
 use limenet\S3BucketStreamZip\S3BucketStreamZip;
 
-class AWSZipStreamServiceProvider extends ServiceProvider
+class AwsZipStreamServiceProvider extends ServiceProvider
 {
     /**
      * Indicates if loading of the provider is deferred.
@@ -21,7 +21,6 @@ class AWSZipStreamServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-
     }
 
     /**
@@ -31,7 +30,7 @@ class AWSZipStreamServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->bind(S3BucketStreamZip::class, function($_) {
+        $this->app->bind(S3BucketStreamZip::class, function ($_) {
             return new S3BucketStreamZip([
                 'key'     => config('services.s3.key'),
                 'secret'  => config('services.s3.secret'),

--- a/examples/simple.php
+++ b/examples/simple.php
@@ -10,7 +10,7 @@ require sprintf('%s/../vendor/autoload.php', __DIR__);
 use JMathai\S3BucketStreamZip\S3BucketStreamZip;
 
 $stream = new S3BucketStreamZip([
-    'key' => 'your-key-goes-here',
+    'key'    => 'your-key-goes-here',
     'secret' => 'your-secret-goes-here',
     'bucket' => 'the-name-of-your-bucket',
     'region' => 'the-region-of-your-bucket',

--- a/examples/simple.php
+++ b/examples/simple.php
@@ -1,4 +1,5 @@
 <?php
+
 // since large buckets may take lots of time we remove any time limits
 set_time_limit(0);
 // set a default time zone in case it's not set
@@ -27,4 +28,3 @@ try {
 } catch (S3Exception $e) {
     echo $e->getMessage();
 }
-

--- a/examples/simple.php
+++ b/examples/simple.php
@@ -9,17 +9,12 @@ require sprintf('%s/../vendor/autoload.php', __DIR__);
 use JMathai\S3BucketStreamZip\S3BucketStreamZip;
 use JMathai\S3BucketStreamZip\Exception\InvalidParameterException;
 
-$stream = new S3BucketStreamZip(
-            // $auth
-            array(
-              'key'     => '*********',   // required
-              'secret'  => '*********'    // required
-            ),
-            // $params
-            array(
-              'Bucket'  => 'bucketname',  // required
-              'Prefix'  => 'subfolder/'   // optional (path to folder to stream)
-            )
-          );
+$stream = new S3BucketStreamZip([
+    'key' => 'your-key-goes-here',
+    'secret' => 'your-secret-goes-here',
+    'bucket' => 'the-name-of-your-bucket',
+    'region' => 'the-region-of-your-bucket',
+    'prefix' => 'prefix-of-the-files-to-zip',
+  ]);
 
 $stream->send('name-of-zipfile-to-send.zip');

--- a/examples/simple.php
+++ b/examples/simple.php
@@ -1,13 +1,14 @@
 <?php
-
 // since large buckets may take lots of time we remove any time limits
 set_time_limit(0);
 // set a default time zone in case it's not set
-date_default_timezone_set('America/Los_Angeles');
+date_default_timezone_set('America/Denver');
 
 require sprintf('%s/../vendor/autoload.php', __DIR__);
 
-use JMathai\S3BucketStreamZip\S3BucketStreamZip;
+use Aws\S3\Exception\S3Exception;
+use limenet\S3BucketStreamZip\Exception\InvalidParameterException;
+use limenet\S3BucketStreamZip\S3BucketStreamZip;
 
 $stream = new S3BucketStreamZip([
     'key'    => 'your-key-goes-here',
@@ -15,6 +16,15 @@ $stream = new S3BucketStreamZip([
     'bucket' => 'the-name-of-your-bucket',
     'region' => 'the-region-of-your-bucket',
     'prefix' => 'prefix-of-the-files-to-zip',
-  ]);
+]);
 
-$stream->send('name-of-zipfile-to-send.zip');
+try {
+    $stream->bucket('test-bucket')
+        ->prefix('some-folder')
+        ->send('name-of-zipfile-to-send.zip');
+} catch (InvalidParameterException $e) {
+    echo $e->getMessage();
+} catch (S3Exception $e) {
+    echo $e->getMessage();
+}
+

--- a/examples/simple.php
+++ b/examples/simple.php
@@ -1,4 +1,5 @@
 <?php
+
 // since large buckets may take lots of time we remove any time limits
 set_time_limit(0);
 // set a default time zone in case it's not set
@@ -7,19 +8,18 @@ date_default_timezone_set('America/Los_Angeles');
 require sprintf('%s/../vendor/autoload.php', __DIR__);
 
 use JMathai\S3BucketStreamZip\S3BucketStreamZip;
-use JMathai\S3BucketStreamZip\Exception\InvalidParameterException;
 
 $stream = new S3BucketStreamZip(
             // $auth
-            array(
+            [
               'key'     => '*********',   // required
-              'secret'  => '*********'    // required
-            ),
+              'secret'  => '*********',    // required
+            ],
             // $params
-            array(
+            [
               'Bucket'  => 'bucketname',  // required
-              'Prefix'  => 'subfolder/'   // optional (path to folder to stream)
-            )
+              'Prefix'  => 'subfolder/',   // optional (path to folder to stream)
+            ]
           );
 
 $stream->send('name-of-zipfile-to-send.zip');

--- a/src/AwsZipStreamServiceProvider.php
+++ b/src/AwsZipStreamServiceProvider.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace limenet\S3BucketStreamZip;
+
+use Illuminate\Support\ServiceProvider;
+
+class AWSZipStreamServiceProvider extends ServiceProvider
+{
+    /**
+     * Indicates if loading of the provider is deferred.
+     *
+     * @var bool
+     */
+    protected $defer = true;
+
+    /**
+     * Bootstrap the application services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+
+    }
+
+    /**
+     * Register the application services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->app->bind(S3BucketStreamZip::class, function($_) {
+            return new S3BucketStreamZip([
+                'key'     => config('services.s3.key'),
+                'secret'  => config('services.s3.secret'),
+                'region'  => config('services.s3.region'),
+                'version' => config('services.s3.version'),
+            ]);
+        });
+    }
+
+    /**
+     * Get the services provided by the provider.
+     *
+     * @return array
+     */
+    public function provides()
+    {
+        return [S3BucketStreamZip::class];
+    }
+}

--- a/src/AwsZipStreamServiceProvider.php
+++ b/src/AwsZipStreamServiceProvider.php
@@ -4,7 +4,7 @@ namespace limenet\S3BucketStreamZip;
 
 use Illuminate\Support\ServiceProvider;
 
-class AWSZipStreamServiceProvider extends ServiceProvider
+class AwsZipStreamServiceProvider extends ServiceProvider
 {
     /**
      * Indicates if loading of the provider is deferred.
@@ -20,7 +20,6 @@ class AWSZipStreamServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-
     }
 
     /**
@@ -30,7 +29,7 @@ class AWSZipStreamServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->bind(S3BucketStreamZip::class, function($_) {
+        $this->app->bind(S3BucketStreamZip::class, function ($_) {
             return new S3BucketStreamZip([
                 'key'     => config('services.s3.key'),
                 'secret'  => config('services.s3.secret'),

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -3,7 +3,8 @@
  * @author Jaisen Mathai <jaisen@jmathai.com>
  * @copyright Copyright 2015, Jaisen Mathai
  */
-
 namespace JMathai\S3BucketStreamZip;
 
-abstract class Exception extends \Exception {}
+abstract class Exception extends \Exception
+{
+}

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -3,6 +3,7 @@
  * @author Jaisen Mathai <jaisen@jmathai.com>
  * @copyright Copyright 2015, Jaisen Mathai
  */
+
 namespace JMathai\S3BucketStreamZip;
 
 abstract class Exception extends \Exception

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -1,10 +1,6 @@
 <?php
-/**
- * @author Jaisen Mathai <jaisen@jmathai.com>
- * @copyright Copyright 2015, Jaisen Mathai
- */
 
-namespace JMathai\S3BucketStreamZip;
+namespace limenet\S3BucketStreamZip;
 
 abstract class Exception extends \Exception
 {

--- a/src/Exception/InvalidParameterException.php
+++ b/src/Exception/InvalidParameterException.php
@@ -8,4 +8,6 @@ namespace JMathai\S3BucketStreamZip\Exception;
 
 use JMathai\S3BucketStreamZip\Exception;
 
-class InvalidParameterException extends Exception {}
+class InvalidParameterException extends Exception
+{
+}

--- a/src/Exception/InvalidParameterException.php
+++ b/src/Exception/InvalidParameterException.php
@@ -1,12 +1,8 @@
 <?php
-/*
- * @author Jaisen Mathai <jaisen@jmathai.com>
- * @copyright Copyright 2015, Jaisen Mathai
- */
 
-namespace JMathai\S3BucketStreamZip\Exception;
+namespace limenet\S3BucketStreamZip\Exception;
 
-use JMathai\S3BucketStreamZip\Exception;
+use limenet\S3BucketStreamZip\Exception;
 
 class InvalidParameterException extends Exception
 {

--- a/src/S3BucketStreamZip.php
+++ b/src/S3BucketStreamZip.php
@@ -9,7 +9,7 @@ use ZipStream\ZipStream;
 
 class S3BucketStreamZip
 {
-    public const MAX_ARCHIVE_SIZE = 1073741824; // 2^30 * 2 = 2 GB
+    public const MAX_ARCHIVE_SIZE = 1073741824;
 
     protected $auth = [];
 

--- a/src/S3BucketStreamZip.php
+++ b/src/S3BucketStreamZip.php
@@ -23,6 +23,7 @@ class S3BucketStreamZip
      * Create a new ZipStream object.
      *
      * @param array $auth - AWS key and secret
+     *
      * @throws InvalidParameterException
      */
     public function __construct($auth, $part = 0)
@@ -57,14 +58,14 @@ class S3BucketStreamZip
 
     public function prefix($prefix)
     {
-        $this->params->setParam('Prefix', rtrim($prefix, '/') . '/');
+        $this->params->setParam('Prefix', rtrim($prefix, '/').'/');
 
         return $this;
     }
 
     public function addParams(array $params)
     {
-        foreach($params as $key => $value) {
+        foreach ($params as $key => $value) {
             $this->params->setParam($key, $value);
         }
 
@@ -72,11 +73,13 @@ class S3BucketStreamZip
     }
 
     /**
-     * Stream a zip file to the client
+     * Stream a zip file to the client.
      *
      * @param string $filename - Name for the file to be sent to the client
-     * $filename will be what is sent in the content-disposition header
+     *                         $filename will be what is sent in the content-disposition header
+     *
      * @throws InvalidParameterException
+     *
      * @internal param array - See the documentation for the List Objects API for valid parameters.
      * Only `Bucket` is required.
      *
@@ -102,7 +105,7 @@ class S3BucketStreamZip
 
             if (is_file("s3://{$params['Bucket']}/{$file['Key']}")) {
                 $context = stream_context_create([
-                    's3' => ['seekable' => true]
+                    's3' => ['seekable' => true],
                 ]);
                 // open seekable(!) stream
                 if ($stream = fopen("s3://{$params['Bucket']}/{$file['Key']}", 'r', false, $context)) {
@@ -134,7 +137,7 @@ class S3BucketStreamZip
             }
             $parts[$currentPart][] = $file;
             $partSizes[$currentPart] += $file['Size'];
-        };
+        }
 
         return $parts;
     }

--- a/src/S3BucketStreamZip.php
+++ b/src/S3BucketStreamZip.php
@@ -18,113 +18,113 @@ use ZipStream;
 class S3BucketStreamZip
 {
     /**
- * @var array
- *
- * http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html
- *
- * {
- *   key: access key,
- *   secret: access secret
- *   bucket: bucket name
- *   region: bucket region
- *   prefix: prefix
- * }
- */
-private $params = [];
+    * @var array
+    *
+    * http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html
+    *
+    * {
+    *   key: access key,
+    *   secret: access secret
+    *   bucket: bucket name
+    *   region: bucket region
+    *   prefix: prefix
+    * }
+    */
+    private $params = [];
 
-/**
- * @var object
- */
-private $s3Client;
+    /**
+    * @var object
+    */
+    private $s3Client;
 
-/**
- * Create a new ZipStream object.
- *
- * @param array $params - AWS key, secret, region, and list object parameters
- */
-public function __construct($params)
-{
-    foreach (['key', 'secret', 'bucket', 'region'] as $key) {
-        if (!isset($params[$key])) {
-            throw new InvalidParameterException('$params parameter to constructor requires a `'.$key.'` attribute');
+    /**
+    * Create a new ZipStream object.
+    *
+    * @param array $params - AWS key, secret, region, and list object parameters
+    */
+    public function __construct($params)
+    {
+        foreach (['key', 'secret', 'bucket', 'region'] as $key) {
+            if (!isset($params[$key])) {
+                throw new InvalidParameterException('$params parameter to constructor requires a `'.$key.'` attribute');
+            }
         }
+
+        $this->params = $params;
+
+        $this->s3Client = new S3Client(
+            [
+                'region'      => $this->params['region'],
+                'version'     => 'latest',
+                'credentials' => [
+                'key'    => $this->params['key'],
+                'secret' => $this->params['secret'],
+            ],
+        ]);
     }
 
-    $this->params = $params;
+    /**
+    * Stream a zip file to the client.
+    *
+    * @param string $filename - Name for the file to be sent to the client
+    * @param array  $params   - Optional parameters
+    * {
+    * expiration: '+10 minutes'
+    * }
+    */
+    public function send($filename, $params = [])
+    {
+        // Set default values for the optional $params argument
+        if (!isset($params['expiration'])) {
+            $params['expiration'] = '+10 minutes';
+        }
 
-    $this->s3Client = new S3Client([
-'region'      => $this->params['region'],
-'version'     => 'latest',
-'credentials' => [
-'key'    => $this->params['key'],
-'secret' => $this->params['secret'],
-],
-]);
-}
+        // Initialize the ZipStream object and pass in the file name which
+        //  will be what is sent in the content-disposition header.
+        // This is the name of the file which will be sent to the client.
+        $zip = new ZipStream\ZipStream($filename);
 
-/**
- * Stream a zip file to the client.
- *
- * @param string $filename - Name for the file to be sent to the client
- * @param array  $params   - Optional parameters
- *                         {
- *                         expiration: '+10 minutes'
- *                         }
- */
-public function send($filename, $params = [])
-{
-    // Set default values for the optional $params argument
-if (!isset($params['expiration'])) {
-    $params['expiration'] = '+10 minutes';
-}
+        // Get a list of objects from the S3 bucket. The iterator is a high
+        //  level abstration that will fetch ALL of the objects without having
+        //  to manually loop over responses.
+        $result = $this->s3Client->getIterator('ListObjects', [
+            'Bucket' => $this->params['bucket'],
+            ]);
 
-// Initialize the ZipStream object and pass in the file name which
-//  will be what is sent in the content-disposition header.
-// This is the name of the file which will be sent to the client.
-$zip = new ZipStream\ZipStream($filename);
-
-// Get a list of objects from the S3 bucket. The iterator is a high
-//  level abstration that will fetch ALL of the objects without having
-//  to manually loop over responses.
-$result = $this->s3Client->getIterator('ListObjects',
-[
-    'Bucket' => $this->params['bucket'],
-]);
-
-// We loop over each object from the ListObjects call.
-foreach ($result as $file) {
-    // We need to use a command to get a request for the S3 object
-//  and then we can get the presigned URL.
-$command = $this->s3Client->getCommand('GetObject', [
-'Bucket' => $this->params['bucket'],
-'Key'    => $file['Key'],
-]);
-    $signedUrl = (string) $this->s3Client->createPresignedRequest($command, $params['expiration'])->getUri();
+        // We loop over each object from the ListObjects call.
+        foreach ($result as $file) {
+            // We need to use a command to get a request for the S3 object
+            //  and then we can get the presigned URL.
+            $command = $this->s3Client->getCommand('GetObject', [
+                'Bucket' => $this->params['bucket'],
+                'Key'    => $file['Key'],
+            ]);
+            $signedUrl = (string) $this->s3Client->createPresignedRequest($command, $params['expiration'])->getUri();
 
 
-// Get the file name on S3 so we can save it to the zip file
-//  using the same name.
-$fileName = basename($file['Key']);
+            // Get the file name on S3 so we can save it to the zip file
+            //  using the same name.
+            $fileName = basename($file['Key']);
 
-// We want to fetch the file to a file pointer so we create it here
-//  and create a curl request and store the response into the file
-//  pointer.
-// After we've fetched the file we add the file to the zip file using
-//  the file pointer and then we close the curl request and the file
-//  pointer.
-// Closing the file pointer removes the file.
-$fp = tmpfile();
-    $ch = curl_init($signedUrl);
-    curl_setopt($ch, CURLOPT_TIMEOUT, 120);
-    curl_setopt($ch, CURLOPT_FILE, $fp);
-    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-    curl_exec($ch);
-    curl_close($ch);
-    $zip->addFileFromStream($fileName, $fp);
-    fclose($fp);
-}
+            // We want to fetch the file to a file pointer so we create it here
+            //  and create a curl request and store the response into the file
+            //  pointer.
+            // After we've fetched the file we add the file to the zip file using
+            //  the file pointer and then we close the curl request and the file
+            //  pointer.
+            // Closing the file pointer removes the file.
+            $fp = tmpfile();
+            $ch = curl_init($signedUrl);
+            curl_setopt($ch, CURLOPT_TIMEOUT, 120);
+            curl_setopt($ch, CURLOPT_FILE, $fp);
+            curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+            curl_exec($ch);
+            curl_close($ch);
+            $zip->addFileFromStream($fileName, $fp);
+            fclose($fp);
+        }
 
-// Finalize the zip file.
-$zip->finish();
-}
+        // Finalize the zip file.
+        $zip->finish();
+    }
 }

--- a/src/S3BucketStreamZip.php
+++ b/src/S3BucketStreamZip.php
@@ -105,7 +105,7 @@ class S3BucketStreamZip
 
             // Get the file name on S3 so we can save it to the zip file
             //  using the same name.
-            $fileName = basename($file['Key']);
+            $fileName = substr($file['Key'], strlen($this->params['prefix']));
 
             // We want to fetch the file to a file pointer so we create it here
             //  and create a curl request and store the response into the file

--- a/src/S3BucketStreamZip.php
+++ b/src/S3BucketStreamZip.php
@@ -1,14 +1,14 @@
 <?php
 /**
- * @author Jaisen Mathai <jaisen@jmathai.com>
- * @copyright Copyright 2015, Jaisen Mathai
- *
- * This library streams the contents from an Amazon S3 bucket
- *  without needing to store the files on disk or download
- *  all of the files before starting to send the archive.
- *
- * Example usage can be found in the examples folder.
- */
+* @author Jaisen Mathai <jaisen@jmathai.com>
+* @copyright Copyright 2015, Jaisen Mathai
+*
+* This library streams the contents from an Amazon S3 bucket
+*  without needing to store the files on disk or download
+*  all of the files before starting to send the archive.
+*
+* Example usage can be found in the examples folder.
+*/
 namespace JMathai\S3BucketStreamZip;
 
 use Aws\S3\S3Client;
@@ -17,120 +17,114 @@ use ZipStream;
 
 class S3BucketStreamZip
 {
-    /**
-   * @var array
-   *
-   * {
-   *   key: your_aws_key,
-   *   secret: your_aws_secret
-   * }
-   */
-  private $auth = [];
+/**
+* @var array
+*
+* http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html
+*
+* {
+*   key: access key,
+*   secret: access secret
+*   bucket: bucket name
+*   region: bucket region
+*   prefix: prefix
+* }
+*/
+private $params = [];
 
-  /**
-   * @var array
-   *
-   * See the documentation for the List Objects API for valid parameters.
-   * Only `Bucket` is required.
-   *
-   * http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html
-   *
-   * {
-   *   Bucket: name_of_bucket
-   * }
-   */
-  private $params = [];
+/**
+* @var object
+*/
+private $s3Client;
 
-  /**
-   * @var object
-   */
-  private $s3Client;
+/**
+* Create a new ZipStream object.
+*
+* @param array $params   - AWS key, secret, region, and list object parameters
+*/
+public function __construct($params)
+{
+foreach (['key', 'secret', 'bucket', 'region'] as $key) {
+if (!isset($params[$key])) {
+throw new InvalidParameterException('$params parameter to constructor requires a `'.$key.'` attribute');
+}
+}
 
-  /**
-   * Create a new ZipStream object.
-   *
-   * @param array $params   - AWS key, secret, region, and list object parameters
-   */
-  public function __construct($params)
-  {
-      foreach (['key', 'secret', 'bucket', 'region'] as $key) {
-          if (!isset($params[$key])) {
-              throw new InvalidParameterException('$params parameter to constructor requires a `'.$key.'` attribute');
-          }
-      }
+$this->params = $params;
 
-      $this->params = $params;
+$this->s3Client = new S3Client([
+'region'      => $this->params['region'],
+'version'     => 'latest',
+'credentials' => [
+'key'    => $this->params['key'],
+'secret' => $this->params['secret'],
+],
+]);
+}
 
-      $this->s3Client = new S3Client([
-      'region'      => $this->params['Region'],
-      'version'     => 'latest',
-      'credentials' => [
-        'key'    => $this->params['key'],
-        'secret' => $this->params['secret'],
-    ],
-    ]);
-  }
+/**
+* Stream a zip file to the client.
+*
+* @param string $filename  - Name for the file to be sent to the client
+* @param array  $params    - Optional parameters
+*  {
+*    expiration: '+10 minutes'
+*  }
+*/
+public function send($filename, $params = [])
+{
+// Set default values for the optional $params argument
+if (!isset($params['expiration'])) {
+$params['expiration'] = '+10 minutes';
+}
 
-  /**
-   * Stream a zip file to the client.
-   *
-   * @param string $filename  - Name for the file to be sent to the client
-   * @param array  $params    - Optional parameters
-   *  {
-   *    expiration: '+10 minutes'
-   *  }
-   */
-  public function send($filename, $params = [])
-  {
-      // Set default values for the optional $params argument
-    if (!isset($params['expiration'])) {
-        $params['expiration'] = '+10 minutes';
-    }
+// Initialize the ZipStream object and pass in the file name which
+//  will be what is sent in the content-disposition header.
+// This is the name of the file which will be sent to the client.
+$zip = new ZipStream\ZipStream($filename);
 
-    // Initialize the ZipStream object and pass in the file name which
-    //  will be what is sent in the content-disposition header.
-    // This is the name of the file which will be sent to the client.
-    $zip = new ZipStream\ZipStream($filename);
+// Get a list of objects from the S3 bucket. The iterator is a high
+//  level abstration that will fetch ALL of the objects without having
+//  to manually loop over responses.
+$result = $this->s3Client->getIterator('ListObjects',
+[
+    'Bucket' => $this->params['bucket'],
+]);
 
-    // Get a list of objects from the S3 bucket. The iterator is a high
-    //  level abstration that will fetch ALL of the objects without having
-    //  to manually loop over responses.
-    $result = $this->s3Client->getIterator('ListObjects', $this->params);
-
-    // We loop over each object from the ListObjects call.
-    foreach ($result as $file) {
-        // We need to use a command to get a request for the S3 object
-      //  and then we can get the presigned URL.
-      $command = $this->s3Client->getCommand('GetObject', [
-        'Bucket' => $this->params['Bucket'],
-        'Key'    => $file['Key'],
-      ]);
-        $signedUrl = (string) $this->s3Client->createPresignedRequest($command, $params['expiration'])->getUri();
+// We loop over each object from the ListObjects call.
+foreach ($result as $file) {
+// We need to use a command to get a request for the S3 object
+//  and then we can get the presigned URL.
+$command = $this->s3Client->getCommand('GetObject', [
+'Bucket' => $this->params['bucket'],
+'Key'    => $file['Key'],
+]);
+$signedUrl = (string) $this->s3Client->createPresignedRequest($command, $params['expiration'])->getUri();
 
 
-      // Get the file name on S3 so we can save it to the zip file
-      //  using the same name.
-      $fileName = basename($file['Key']);
+// Get the file name on S3 so we can save it to the zip file
+//  using the same name.
+$fileName = basename($file['Key']);
 
-      // We want to fetch the file to a file pointer so we create it here
-      //  and create a curl request and store the response into the file
-      //  pointer.
-      // After we've fetched the file we add the file to the zip file using
-      //  the file pointer and then we close the curl request and the file
-      //  pointer.
-      // Closing the file pointer removes the file.
-      $fp = tmpfile();
-        $ch = curl_init($signedUrl);
-        curl_setopt($ch, CURLOPT_TIMEOUT, 120);
-        curl_setopt($ch, CURLOPT_FILE, $fp);
-        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-        curl_exec($ch);
-        curl_close($ch);
-        $zip->addFileFromStream($fileName, $fp);
-        fclose($fp);
-    }
+// We want to fetch the file to a file pointer so we create it here
+//  and create a curl request and store the response into the file
+//  pointer.
+// After we've fetched the file we add the file to the zip file using
+//  the file pointer and then we close the curl request and the file
+//  pointer.
+// Closing the file pointer removes the file.
+$fp = tmpfile();
+$ch = curl_init($signedUrl);
+curl_setopt($ch, CURLOPT_TIMEOUT, 120);
+curl_setopt($ch, CURLOPT_FILE, $fp);
+curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+curl_exec($ch);
+curl_close($ch);
+$zip->addFileFromStream($fileName, $fp);
+fclose($fp);
+}
 
-    // Finalize the zip file.
-    $zip->finish();
-  }
+// Finalize the zip file.
+$zip->finish();
+}
 }

--- a/src/S3BucketStreamZip.php
+++ b/src/S3BucketStreamZip.php
@@ -92,14 +92,11 @@ class S3BucketStreamZip
         $this->doesDirectoryExist($params);
 
         $zip = new ZipStream($filename);
-        // The iterator fetches ALL of the objects without having to manually loop over responses.
-        $files = $this->s3Client->getIterator('ListObjects', $params);
 
         $parts = $this->parts();
 
         // Add each object from the ListObjects call to the new zip file.
         foreach ($parts[$this->part] as $file) {
-            var_dump($file['Size']);
             // Get the file name on S3 so we can save it to the zip file using the same name.
             $fileName = basename($file['Key']);
 
@@ -124,6 +121,7 @@ class S3BucketStreamZip
 
         $this->doesDirectoryExist($params);
 
+        // The iterator fetches ALL of the objects without having to manually loop over responses.
         $files = $this->s3Client->getIterator('ListObjects', $params);
 
         $parts = [0 => []];

--- a/src/S3BucketStreamZip.php
+++ b/src/S3BucketStreamZip.php
@@ -89,7 +89,8 @@ class S3BucketStreamZip
         //  to manually loop over responses.
         $result = $this->s3Client->getIterator('ListObjects', [
             'Bucket' => $this->params['bucket'],
-            ]);
+            'Prefix' => $this->params['prefix'],
+        ]);
 
         // We loop over each object from the ListObjects call.
         foreach ($result as $file) {

--- a/src/S3BucketStreamZip.php
+++ b/src/S3BucketStreamZip.php
@@ -9,7 +9,7 @@ use ZipStream\ZipStream;
 
 class S3BucketStreamZip
 {
-    public const MAX_ARCHIVE_SIZE = 2147483648; // 2^30 * 2 = 2 GB
+    public const MAX_ARCHIVE_SIZE = 1073741824; // 2^30 * 2 = 2 GB
 
     protected $auth = [];
 

--- a/src/S3BucketStreamZip.php
+++ b/src/S3BucketStreamZip.php
@@ -9,6 +9,7 @@
 *
 * Example usage can be found in the examples folder.
 */
+
 namespace JMathai\S3BucketStreamZip;
 
 use Aws\S3\S3Client;
@@ -101,7 +102,6 @@ class S3BucketStreamZip
                 'Key'    => $file['Key'],
             ]);
             $signedUrl = (string) $this->s3Client->createPresignedRequest($command, $params['expiration'])->getUri();
-
 
             // Get the file name on S3 so we can save it to the zip file
             //  using the same name.

--- a/src/S3BucketStreamZip.php
+++ b/src/S3BucketStreamZip.php
@@ -18,30 +18,30 @@ use ZipStream;
 class S3BucketStreamZip
 {
     /**
-    * @var array
-    *
-    * http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html
-    *
-    * {
-    *   key: access key,
-    *   secret: access secret
-    *   bucket: bucket name
-    *   region: bucket region
-    *   prefix: prefix
-    * }
-    */
+     * @var array
+     *
+     * http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html
+     *
+     * {
+     *   key: access key,
+     *   secret: access secret
+     *   bucket: bucket name
+     *   region: bucket region
+     *   prefix: prefix
+     * }
+     */
     private $params = [];
 
     /**
-    * @var object
-    */
+     * @var object
+     */
     private $s3Client;
 
     /**
-    * Create a new ZipStream object.
-    *
-    * @param array $params - AWS key, secret, region, and list object parameters
-    */
+     * Create a new ZipStream object.
+     *
+     * @param array $params - AWS key, secret, region, and list object parameters
+     */
     public function __construct($params)
     {
         foreach (['key', 'secret', 'bucket', 'region'] as $key) {
@@ -64,14 +64,14 @@ class S3BucketStreamZip
     }
 
     /**
-    * Stream a zip file to the client.
-    *
-    * @param string $filename - Name for the file to be sent to the client
-    * @param array  $params   - Optional parameters
-    * {
-    * expiration: '+10 minutes'
-    * }
-    */
+     * Stream a zip file to the client.
+     *
+     * @param string $filename - Name for the file to be sent to the client
+     * @param array  $params   - Optional parameters
+     *                         {
+     *                         expiration: '+10 minutes'
+     *                         }
+     */
     public function send($filename, $params = [])
     {
         // Set default values for the optional $params argument

--- a/src/S3BucketStreamZip.php
+++ b/src/S3BucketStreamZip.php
@@ -17,42 +17,42 @@ use ZipStream;
 
 class S3BucketStreamZip
 {
-/**
-* @var array
-*
-* http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html
-*
-* {
-*   key: access key,
-*   secret: access secret
-*   bucket: bucket name
-*   region: bucket region
-*   prefix: prefix
-* }
-*/
+    /**
+ * @var array
+ *
+ * http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html
+ *
+ * {
+ *   key: access key,
+ *   secret: access secret
+ *   bucket: bucket name
+ *   region: bucket region
+ *   prefix: prefix
+ * }
+ */
 private $params = [];
 
 /**
-* @var object
-*/
+ * @var object
+ */
 private $s3Client;
 
 /**
-* Create a new ZipStream object.
-*
-* @param array $params   - AWS key, secret, region, and list object parameters
-*/
+ * Create a new ZipStream object.
+ *
+ * @param array $params - AWS key, secret, region, and list object parameters
+ */
 public function __construct($params)
 {
-foreach (['key', 'secret', 'bucket', 'region'] as $key) {
-if (!isset($params[$key])) {
-throw new InvalidParameterException('$params parameter to constructor requires a `'.$key.'` attribute');
-}
-}
+    foreach (['key', 'secret', 'bucket', 'region'] as $key) {
+        if (!isset($params[$key])) {
+            throw new InvalidParameterException('$params parameter to constructor requires a `'.$key.'` attribute');
+        }
+    }
 
-$this->params = $params;
+    $this->params = $params;
 
-$this->s3Client = new S3Client([
+    $this->s3Client = new S3Client([
 'region'      => $this->params['region'],
 'version'     => 'latest',
 'credentials' => [
@@ -63,19 +63,19 @@ $this->s3Client = new S3Client([
 }
 
 /**
-* Stream a zip file to the client.
-*
-* @param string $filename  - Name for the file to be sent to the client
-* @param array  $params    - Optional parameters
-*  {
-*    expiration: '+10 minutes'
-*  }
-*/
+ * Stream a zip file to the client.
+ *
+ * @param string $filename - Name for the file to be sent to the client
+ * @param array  $params   - Optional parameters
+ *                         {
+ *                         expiration: '+10 minutes'
+ *                         }
+ */
 public function send($filename, $params = [])
 {
-// Set default values for the optional $params argument
+    // Set default values for the optional $params argument
 if (!isset($params['expiration'])) {
-$params['expiration'] = '+10 minutes';
+    $params['expiration'] = '+10 minutes';
 }
 
 // Initialize the ZipStream object and pass in the file name which
@@ -93,13 +93,13 @@ $result = $this->s3Client->getIterator('ListObjects',
 
 // We loop over each object from the ListObjects call.
 foreach ($result as $file) {
-// We need to use a command to get a request for the S3 object
+    // We need to use a command to get a request for the S3 object
 //  and then we can get the presigned URL.
 $command = $this->s3Client->getCommand('GetObject', [
 'Bucket' => $this->params['bucket'],
 'Key'    => $file['Key'],
 ]);
-$signedUrl = (string) $this->s3Client->createPresignedRequest($command, $params['expiration'])->getUri();
+    $signedUrl = (string) $this->s3Client->createPresignedRequest($command, $params['expiration'])->getUri();
 
 
 // Get the file name on S3 so we can save it to the zip file
@@ -114,14 +114,14 @@ $fileName = basename($file['Key']);
 //  pointer.
 // Closing the file pointer removes the file.
 $fp = tmpfile();
-$ch = curl_init($signedUrl);
-curl_setopt($ch, CURLOPT_TIMEOUT, 120);
-curl_setopt($ch, CURLOPT_FILE, $fp);
-curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-curl_exec($ch);
-curl_close($ch);
-$zip->addFileFromStream($fileName, $fp);
-fclose($fp);
+    $ch = curl_init($signedUrl);
+    curl_setopt($ch, CURLOPT_TIMEOUT, 120);
+    curl_setopt($ch, CURLOPT_FILE, $fp);
+    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+    curl_exec($ch);
+    curl_close($ch);
+    $zip->addFileFromStream($fileName, $fp);
+    fclose($fp);
 }
 
 // Finalize the zip file.

--- a/src/S3Params.php
+++ b/src/S3Params.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace limenet\S3BucketStreamZip;
+
+class S3Params
+{
+    public $params;
+
+    public function __construct($bucket)
+    {
+        $this->params['Bucket'] = $bucket;
+    }
+
+    public function getParams()
+    {
+        return $this->params;
+    }
+
+    public function setParam($key, $value)
+    {
+        $this->params[$key] = $value;
+    }
+}

--- a/tests/S3BucketStreamZipTest.php
+++ b/tests/S3BucketStreamZipTest.php
@@ -3,7 +3,6 @@
  * @author Jaisen Mathai <jaisen@jmathai.com>
  * @copyright Copyright 2015, Jaisen Mathai
  */
-
 namespace JMathai\S3BucketStreamZipTest;
 
 use JMathai\S3BucketStreamZip\S3BucketStreamZip;
@@ -11,32 +10,32 @@ use PHPUnit_Framework_TestCase;
 
 class S3BucketStreamZipTest extends PHPUnit_Framework_TestCase
 {
-  /**
-  * @expectedException \JMathai\S3BucketStreamZip\Exception\InvalidParameterException
-  */
+    /**
+   * @expectedException \JMathai\S3BucketStreamZip\Exception\InvalidParameterException
+   */
   public function testInvalidParamsToConstructorKey()
   {
-    $client = new S3BucketStreamZip(array(), array());
+      $client = new S3BucketStreamZip([], []);
   }
 
   /**
-  * @expectedException \JMathai\S3BucketStreamZip\Exception\InvalidParameterException
-  */
+   * @expectedException \JMathai\S3BucketStreamZip\Exception\InvalidParameterException
+   */
   public function testInvalidParamsToConstructorSecret()
   {
-    $client = new S3BucketStreamZip(array('key' => 'foo'), array());
+      $client = new S3BucketStreamZip(['key' => 'foo'], []);
   }
 
   /**
-  * @expectedException \JMathai\S3BucketStreamZip\Exception\InvalidParameterException
-  */
+   * @expectedException \JMathai\S3BucketStreamZip\Exception\InvalidParameterException
+   */
   public function testInvalidParamsToConstructorBucket()
   {
-    $client = new S3BucketStreamZip(array('key' => 'foo', 'secret' => 'bar'), array());
+      $client = new S3BucketStreamZip(['key' => 'foo', 'secret' => 'bar'], []);
   }
 
-  public function testValidParamsToConstructor()
-  {
-    $client = new S3BucketStreamZip(array('key' => 'foo', 'secret' => 'bar'), array('Bucket' => 'foobar'));
-  }
+    public function testValidParamsToConstructor()
+    {
+        $client = new S3BucketStreamZip(['key' => 'foo', 'secret' => 'bar'], ['Bucket' => 'foobar']);
+    }
 }

--- a/tests/S3BucketStreamZipTest.php
+++ b/tests/S3BucketStreamZipTest.php
@@ -3,6 +3,7 @@
  * @author Jaisen Mathai <jaisen@jmathai.com>
  * @copyright Copyright 2015, Jaisen Mathai
  */
+
 namespace JMathai\S3BucketStreamZipTest;
 
 use JMathai\S3BucketStreamZip\S3BucketStreamZip;

--- a/tests/S3BucketStreamZipTest.php
+++ b/tests/S3BucketStreamZipTest.php
@@ -1,42 +1,43 @@
 <?php
-/**
- * @author Jaisen Mathai <jaisen@jmathai.com>
- * @copyright Copyright 2015, Jaisen Mathai
- */
 
-namespace JMathai\S3BucketStreamZipTest;
+namespace limenet\S3BucketStreamZipTest;
 
-use JMathai\S3BucketStreamZip\S3BucketStreamZip;
+use limenet\S3BucketStreamZip\S3BucketStreamZip;
 use PHPUnit_Framework_TestCase;
 
 class S3BucketStreamZipTest extends PHPUnit_Framework_TestCase
 {
     /**
-   * @expectedException \JMathai\S3BucketStreamZip\Exception\InvalidParameterException
-   */
-  public function testInvalidParamsToConstructorKey()
-  {
-      $client = new S3BucketStreamZip([]);
-  }
+     * @expectedException \limenet\S3BucketStreamZip\Exception\InvalidParameterException
+     */
+    public function testInvalidParamsToConstructorKey()
+    {
+        $client = new S3BucketStreamZip([], []);
+    }
 
-  /**
-   * @expectedException \JMathai\S3BucketStreamZip\Exception\InvalidParameterException
-   */
-  public function testInvalidParamsToConstructorSecret()
-  {
-      $client = new S3BucketStreamZip(['key' => 'foo']);
-  }
+    /**
+     * @expectedException \limenet\S3BucketStreamZip\Exception\InvalidParameterException
+     */
+    public function testInvalidParamsToConstructorSecret()
+    {
+        $client = new S3BucketStreamZip(['key' => 'foo'], []);
+    }
 
-  /**
-   * @expectedException \JMathai\S3BucketStreamZip\Exception\InvalidParameterException
-   */
-  public function testInvalidParamsToConstructorBucket()
-  {
-      $client = new S3BucketStreamZip(['key' => 'foo', 'secret' => 'bar']);
-  }
+    /**
+     * @expectedException \limenet\S3BucketStreamZip\Exception\InvalidParameterException
+     */
+    public function testInvalidParamsToConstructorBucket()
+    {
+        $client = new S3BucketStreamZip(['key' => 'foo', 'secret' => 'bar'], []);
+    }
 
     public function testValidParamsToConstructor()
     {
-        $client = new S3BucketStreamZip(['key' => 'foo', 'secret' => 'bar', 'bucket' => 'foobar', 'region' => 'baz']);
+        $client = new S3BucketStreamZip([
+            'key'     => 'foo',
+            'secret'  => 'bar',
+            'region'  => '',
+            'version' => 'latest',
+        ], ['Bucket' => 'foobar']);
     }
 }

--- a/tests/S3BucketStreamZipTest.php
+++ b/tests/S3BucketStreamZipTest.php
@@ -15,7 +15,7 @@ class S3BucketStreamZipTest extends PHPUnit_Framework_TestCase
    */
   public function testInvalidParamsToConstructorKey()
   {
-      $client = new S3BucketStreamZip([], []);
+      $client = new S3BucketStreamZip([]);
   }
 
   /**
@@ -23,7 +23,7 @@ class S3BucketStreamZipTest extends PHPUnit_Framework_TestCase
    */
   public function testInvalidParamsToConstructorSecret()
   {
-      $client = new S3BucketStreamZip(['key' => 'foo'], []);
+      $client = new S3BucketStreamZip(['key' => 'foo']);
   }
 
   /**
@@ -31,11 +31,11 @@ class S3BucketStreamZipTest extends PHPUnit_Framework_TestCase
    */
   public function testInvalidParamsToConstructorBucket()
   {
-      $client = new S3BucketStreamZip(['key' => 'foo', 'secret' => 'bar'], []);
+      $client = new S3BucketStreamZip(['key' => 'foo', 'secret' => 'bar']);
   }
 
     public function testValidParamsToConstructor()
     {
-        $client = new S3BucketStreamZip(['key' => 'foo', 'secret' => 'bar'], ['Bucket' => 'foobar']);
+        $client = new S3BucketStreamZip(['key' => 'foo', 'secret' => 'bar', 'bucket' => 'foobar', 'region' => 'baz']);
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,3 +1,4 @@
 <?php
+
 date_default_timezone_set('UTC');
 require sprintf('%s/../vendor/autoload.php', __DIR__);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,5 @@
 <?php
+
 date_default_timezone_set('UTC');
 
 require sprintf('%s/../vendor/autoload.php', __DIR__);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,4 @@
 <?php
-
 date_default_timezone_set('UTC');
+
 require sprintf('%s/../vendor/autoload.php', __DIR__);


### PR DESCRIPTION
Thanks a lot for this class, exactly what I was looking for. However, since I needed to use v3 of the AWS SDK for PHP (due to Laravel and bucket location), I forked it and made a few changes.

---

This PR updates the library to use the v3 of the SDK, which is required to access S3 buckets which only support modern/more recent ciphers for encryption -- and it makes it compatible to use with e.g. Laravel 5.2.

The following changes were made:
- Use AWS SDK for PHP v3
- Use StyleCI to have a unified code style
- changed the constructor to make it compatible with v3
- include the non-prefix part of the filename in the ZIP which essentially allows for multiple folders in the archive

Thus, this probably warrants a [major release according to semver](http://semver.org/) as **there are breaking changes**.

Taken from the `examples/simple.php`, the new constructor looks like this:

``` php
$stream = new S3BucketStreamZip([
    'key'    => 'your-key-goes-here',
    'secret' => 'your-secret-goes-here',
    'bucket' => 'the-name-of-your-bucket',
    'region' => 'the-region-of-your-bucket',
    'prefix' => 'prefix-of-the-files-to-zip',
]);
```

I'm using these changes in a production environment with no issues so far. Let me know if you want me to make any changes!
